### PR TITLE
Chore: Use vanity address for yarn tests

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,5 @@
 [programs.localnet]
-monaco_protocol = "4UqmjWpDxXA7jgmfDYxmxj4fYrPCEXMRn95nJ3Uko9Ay"
+monaco_protocol = "monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih"
 
 [registry]
 url = "https://anchor.projectserum.com"

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -18,11 +18,6 @@ pub mod error;
 pub mod instructions;
 pub mod state;
 
-#[cfg(feature = "stable")]
-declare_id!("5Q2hKsxShaPxFqgVtQH3ErTkiBf8NGb99nmpaGw7FCrr");
-#[cfg(feature = "dev")]
-declare_id!("yxvZ2jHThHQPTN6mGC8Z4i7iVBtQb3eBGeURQuLSrG9");
-#[cfg(not(any(feature = "stable", feature = "dev")))]
 declare_id!("monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih");
 
 #[program]

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -18,6 +18,11 @@ pub mod error;
 pub mod instructions;
 pub mod state;
 
+#[cfg(feature = "stable")]
+declare_id!("5Q2hKsxShaPxFqgVtQH3ErTkiBf8NGb99nmpaGw7FCrr");
+#[cfg(feature = "dev")]
+declare_id!("yxvZ2jHThHQPTN6mGC8Z4i7iVBtQb3eBGeURQuLSrG9");
+#[cfg(not(any(feature = "stable", feature = "dev")))]
 declare_id!("monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih");
 
 #[program]


### PR DESCRIPTION
Because of the `features = ` `stable/dev` flags we use for devnet, we must use the vanity address for `localnet` tests