### PR TITLE
fix: restrict market updates to market authority

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     hooks:
     -   id: fmt
     -   id: cargo-check
-    -   id: clippy
 -   repo: local
     hooks:
     -   id: generate-admin-client-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     hooks:
     -   id: fmt
     -   id: cargo-check
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: clippy
+        args: ["--", "-D", "warnings", "-A", "clippy::result_large_err"]
 -   repo: local
     hooks:
     -   id: generate-admin-client-docs

--- a/admin/add_prices_to_ladder.ts
+++ b/admin/add_prices_to_ladder.ts
@@ -36,10 +36,11 @@ export async function addPricesToLadder() {
         protocolProgram,
       );
       await protocolProgram.methods
-        .addPricesToMarketOutcome(marketPda, marketOutcomeIndex, pricesToAdd)
+        .addPricesToMarketOutcome(marketOutcomeIndex, pricesToAdd)
         .accounts({
           systemProgram: SystemProgram.programId,
           outcome: marketOutcomePda,
+          market: marketPda,
           marketOperator: getAnchorProvider().wallet.publicKey,
           authorisedOperators: authorisedOperators.data.pda,
         })

--- a/npm-admin-client/src/market_outcome_prices.ts
+++ b/npm-admin-client/src/market_outcome_prices.ts
@@ -54,10 +54,11 @@ export async function addPricesToOutcome(
 
   try {
     const tnxId = await program.methods
-      .addPricesToMarketOutcome(marketPk, outcomeIndex, priceLadder)
+      .addPricesToMarketOutcome(outcomeIndex, priceLadder)
       .accounts({
         systemProgram: SystemProgram.programId,
         outcome: marketOutcomePda.data.pda,
+        market: marketPk,
         authorisedOperators: authorisedOperatorsPda.data.pda,
         marketOperator: provider.wallet.publicKey,
       })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^4.5.4"
   },
   "scripts": {
-    "build": "cd npm-client && npm run build && cd - && cd npm-admin-client && npm run build && cd - && anchor build",
+    "build": "cd npm-client && npm install && npm run build && cd - && cd npm-admin-client && npm install && npm run build && cd - && anchor build",
     "test": "anchor test",
     "runJestTests": "jest --silent --forceExit",
     "lint": "eslint --fix .",

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -385,7 +385,7 @@ pub struct InitializeMarketOutcome<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(_market: Pubkey, _outcome_index: u16)]
+#[instruction(_outcome_index: u16)]
 pub struct UpdateMarketOutcome<'info> {
     #[account(address = system_program::ID)]
     pub system_program: Program<'info, System>,
@@ -393,12 +393,16 @@ pub struct UpdateMarketOutcome<'info> {
     #[account(
         mut,
         seeds = [
-            _market.as_ref(),
+            market.key().as_ref(),
             _outcome_index.to_string().as_ref(),
         ],
         bump,
+        constraint = _outcome_index < market.market_outcomes_count
     )]
     pub outcome: Account<'info, MarketOutcome>,
+
+    #[account(mut)]
+    pub market: Account<'info, Market>,
 
     #[account(mut)]
     pub market_operator: Signer<'info>,

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -397,7 +397,6 @@ pub struct UpdateMarketOutcome<'info> {
             _outcome_index.to_string().as_ref(),
         ],
         bump,
-        constraint = _outcome_index < market.market_outcomes_count
     )]
     pub outcome: Account<'info, MarketOutcome>,
 

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -639,7 +639,7 @@ pub struct CloseMarketMatchingPool<'info> {
             market.key().as_ref(),
             market_outcome.index.to_string().as_ref(),
             b"-".as_ref(),
-            format!("{:.3}", _price).as_ref(),
+            format!("{_price:.3}").as_ref(),
             _for_outcome.to_string().as_ref(),
         ],
         bump,

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -145,6 +145,8 @@ pub enum CoreError {
     MarketNotSettled,
     #[msg("Market: market is not ready to close")]
     MarketNotReadyToClose,
+    #[msg("Market: market authority does not match operator")]
+    MarketAuthorityMismatch,
 
     /*
     MultisigGroup

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -79,7 +79,7 @@ fn verify_prices_precision(prices: &[f64]) -> Result<()> {
     require!(
         prices
             .iter()
-            .all(|&value| format!("{}", value) <= format!("{:.3}", value)),
+            .all(|&value| format!("{value}") <= format!("{value:.3}")),
         CoreError::MarketPricePrecisionTooLarge
     );
     Ok(())

--- a/programs/monaco_protocol/src/instructions/market/market_authority.rs
+++ b/programs/monaco_protocol/src/instructions/market/market_authority.rs
@@ -1,0 +1,11 @@
+use crate::error::CoreError;
+use anchor_lang::prelude::*;
+use solana_program::pubkey::Pubkey;
+
+pub fn verify_market_authority(operator: &Pubkey, market_authority: &Pubkey) -> Result<()> {
+    require!(
+        market_authority.eq(operator),
+        CoreError::MarketAuthorityMismatch
+    );
+    Ok(())
+}

--- a/programs/monaco_protocol/src/instructions/market/mod.rs
+++ b/programs/monaco_protocol/src/instructions/market/mod.rs
@@ -1,9 +1,11 @@
 mod create_market;
+mod market_authority;
 mod update_market_locktime;
 mod update_market_status;
 mod update_market_title;
 
 pub use create_market::*;
+pub use market_authority::*;
 pub use update_market_locktime::*;
 pub use update_market_status::*;
 pub use update_market_title::*;

--- a/programs/monaco_protocol/src/instructions/product.rs
+++ b/programs/monaco_protocol/src/instructions/product.rs
@@ -26,7 +26,7 @@ pub fn create_product_config(
         CoreError::ProductConfigTitleLen
     );
     require!(
-        format!("{}", commission_rate) <= format!("{:.3}", commission_rate),
+        format!("{commission_rate}") <= format!("{commission_rate:.3}"),
         CoreError::CommissionPrecisionTooLarge
     );
 

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::context::*;
 use crate::error::CoreError;
+use crate::instructions::market::verify_market_authority;
 use crate::instructions::verify_operator_authority;
 use crate::state::market_account::{
     Market, MarketMatchingPool, MarketOutcome, MarketStatus::ReadyToClose,
@@ -181,6 +182,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::initialize_outcome(ctx, title, price_ladder)?;
         msg!("Initialized market outcome");
         Ok(())
@@ -188,7 +194,6 @@ pub mod monaco_protocol {
 
     pub fn add_prices_to_market_outcome(
         ctx: Context<UpdateMarketOutcome>,
-        _market: Pubkey,
         _outcome_index: u16,
         new_prices: Vec<f64>,
     ) -> Result<()> {
@@ -196,6 +201,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::add_prices_to_market_outcome(&mut ctx.accounts.outcome, new_prices)?;
         Ok(())
     }
@@ -205,6 +215,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::update_title(ctx, title)
     }
 
@@ -213,6 +228,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::update_locktime(ctx, lock_time)
     }
 
@@ -221,6 +241,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::open(&mut ctx.accounts.market)
     }
 
@@ -229,12 +254,21 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
 
         let settle_time = Clock::get().unwrap().unix_timestamp;
         instructions::market::settle(&mut ctx.accounts.market, winning_outcome_index, settle_time)
     }
 
     pub fn complete_market_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
+        verify_operator_authority(
+            ctx.accounts.crank_operator.key,
+            &ctx.accounts.authorised_operators,
+        )?;
+
         instructions::market::complete_settlement(ctx)
     }
 
@@ -243,6 +277,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::publish(ctx)
     }
 
@@ -251,6 +290,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::unpublish(ctx)
     }
 
@@ -259,6 +303,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::suspend(ctx)
     }
 
@@ -267,6 +316,11 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
         instructions::market::unsuspend(ctx)
     }
 
@@ -275,10 +329,12 @@ pub mod monaco_protocol {
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
         )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
 
-        instructions::market::ready_to_close(&mut ctx.accounts.market)?;
-
-        Ok(())
+        instructions::market::ready_to_close(&mut ctx.accounts.market)
     }
 
     pub fn create_product_config(

--- a/tests/market/create_market.ts
+++ b/tests/market/create_market.ts
@@ -121,9 +121,10 @@ describe("Market: creation", () => {
     const pricesToAdd = [9.999, 9.99, 9.9];
 
     await monaco.program.methods
-      .addPricesToMarketOutcome(market.pk, 0, pricesToAdd)
+      .addPricesToMarketOutcome(0, pricesToAdd)
       .accounts({
         outcome: market.outcomePks[0],
+        market: market.pk,
         authorisedOperators: await monaco.findMarketAuthorisedOperatorsPda(),
         marketOperator: monaco.operatorPk,
         systemProgram: SystemProgram.programId,

--- a/tests/npm-admin-client/market_create.ts
+++ b/tests/npm-admin-client/market_create.ts
@@ -85,6 +85,7 @@ describe("Admin Client Create Full Market", () => {
       market.data.marketPk,
     );
 
+    assert.deepEqual(market.errors, []);
     assert(market.success);
     assert(market.data.market);
     assert(market.data.priceLadderResults);

--- a/tests/npm-admin-client/market_create.ts
+++ b/tests/npm-admin-client/market_create.ts
@@ -85,11 +85,11 @@ describe("Admin Client Create Full Market", () => {
       market.data.marketPk,
     );
 
-    assert.deepEqual(market.errors, []);
     assert(market.success);
     assert(market.data.market);
     assert(market.data.priceLadderResults);
     assert(market.data.tnxId);
+    assert.deepEqual(market.errors, []);
     assert.deepEqual(market.data.market.mintAccount, newMintPk);
     assert.deepEqual(market.data.market.title, marketTitle);
     assert.equal(market.data.priceLadderResults.length, marketOutcomes.length);

--- a/tests/npm-admin-client/market_create.ts
+++ b/tests/npm-admin-client/market_create.ts
@@ -90,7 +90,6 @@ describe("Admin Client Create Full Market", () => {
     assert(market.data.market);
     assert(market.data.priceLadderResults);
     assert(market.data.tnxId);
-    assert.deepEqual(market.errors, []);
     assert.deepEqual(market.data.market.mintAccount, newMintPk);
     assert.deepEqual(market.data.market.title, marketTitle);
     assert.equal(market.data.priceLadderResults.length, marketOutcomes.length);


### PR DESCRIPTION
Any instructions that update or affect a market should only be permitted to be run by the given market's authority.

This PR verifies that the authorised market operator matches the market authority for the below instructions. If the operator does not match the authority then a `MarketAuthorityMismatch` error is returned. 
* `initialize_market_outcome`
* `add_prices_to_market_outcome`
* `update_market_title`
* `update_market_locktime`
* `open_market`
* `settle_market`
* `complete_market_settlement`
* `publish_market`
* `unpublish_market`
*  `suspend_market`
*  `unsuspend_market`
*  `set_market_ready_to_close`

The following changes are also included:
* `yarn build` will now also run `npm install` for each of typescript clients before attempting to `npm run build` on them. 
* Run time args for the git hook that runs `clippy` have been included in `.pre-commit-config.yaml`. A recent version of clippy has included an new lint that the Anchor framework hits anywhere a `Result<()>` is returned. This lint is now disabled in the codebase (`-A [allowed]`). 
* Various changes to otherwise appease clippy, mainly around `format` strings, and the fact that now variables can be included in the format string itself (though not fields, i.e., `x` but not `x.y`). 