### PR TITLE
Update price precision checking to be more correct

### DIFF
--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -79,7 +79,7 @@ fn verify_prices_precision(prices: &[f64]) -> Result<()> {
     require!(
         prices
             .iter()
-            .all(|&value| format!("{value}") <= format!("{value:.3}")),
+            .all(|&value| (format!("{value}")).len() <= (format!("{value:.3}")).len()),
         CoreError::MarketPricePrecisionTooLarge
     );
     Ok(())
@@ -161,5 +161,8 @@ mod tests {
 
         let not_ok_3 = verify_prices_precision(&vec![1.111, 1.11, 1.1, 1_f64, 1.1111]);
         assert!(not_ok_3.is_err());
+
+        let attempting_to_round_not_ok = verify_prices_precision(&vec![1.1118]);
+        assert!(attempting_to_round_not_ok.is_err());
     }
 }


### PR DESCRIPTION
It was shown that a simple example of `1.1118` would pass precision checking whereas it should fail. This change fixes this so that precision is actually being checked. 

Before
```
"1.1118" <= "1.112"
```

Now
```
6 <= 5
```