### PR TITLE
fix: Additional checks for closing orders/settling markets

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -425,11 +425,11 @@ pub struct CompleteMarketSettlement<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(
-    mut,
-    token::mint = market.mint_account,
-    token::authority = market_escrow,
-    seeds = [b"escrow".as_ref(), market.key().as_ref()],
-    bump,
+        mut,
+        token::mint = market.mint_account,
+        token::authority = market_escrow,
+        seeds = [b"escrow".as_ref(), market.key().as_ref()],
+        bump,
     )]
     pub market_escrow: Box<Account<'info, TokenAccount>>,
 

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -424,6 +424,14 @@ pub struct UpdateMarket<'info> {
 pub struct CompleteMarketSettlement<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
+    #[account(
+    mut,
+    token::mint = market.mint_account,
+    token::authority = market_escrow,
+    seeds = [b"escrow".as_ref(), market.key().as_ref()],
+    bump,
+    )]
+    pub market_escrow: Box<Account<'info, TokenAccount>>,
 
     #[account(mut)]
     pub crank_operator: Signer<'info>,

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -54,6 +54,8 @@ pub enum CoreError {
     SettlementMarketNotSettled,
     #[msg("Core Settlement: market not ready for settlement")]
     SettlementMarketNotReadyForSettlement,
+    #[msg("Core Settlement: market escrow is non zero")]
+    SettlementMarketEscrowNonZero,
 
     /*
     Authorised Operator
@@ -180,6 +182,8 @@ pub enum CoreError {
     /*
     Close Account
      */
+    #[msg("CloseAccount: Order not complete")]
+    CloseAccountOrderNotComplete,
     #[msg("CloseAccount: Purchaser does not match")]
     CloseAccountPurchaserMismatch,
     #[msg("CloseAccount: Market does not match")]

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -37,6 +37,11 @@ pub fn settle(
 }
 
 pub fn complete_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
+    require!(
+        ctx.accounts.market_escrow.amount == 0_u64,
+        CoreError::SettlementMarketEscrowNonZero
+    );
+
     let market = &mut ctx.accounts.market;
     require!(
         ReadyForSettlement.eq(&market.market_status),

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -451,6 +451,11 @@ pub mod monaco_protocol {
             CoreError::MarketNotReadyToClose
         );
 
+        require!(
+            ctx.accounts.order.is_completed(),
+            CoreError::CloseAccountOrderNotComplete
+        );
+
         Ok(())
     }
 

--- a/tests/market/update_market_status.ts
+++ b/tests/market/update_market_status.ts
@@ -71,6 +71,7 @@ describe("Market: update status", () => {
       .completeMarketSettlement()
       .accounts({
         market: market.pk,
+        marketEscrow: market.escrowPk,
         authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         crankOperator: monaco.operatorPk,
       })

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -857,6 +857,7 @@ export class MonacoMarket {
       .completeMarketSettlement()
       .accounts({
         market: this.pk,
+        marketEscrow: this.escrowPk,
         crankOperator: this.monaco.operatorPk,
         authorisedOperators:
           await this.monaco.findCrankAuthorisedOperatorsPda(),


### PR DESCRIPTION
Tightening up operations to settle/close some of the accounts. 

1. Prevent market settlement completing while there is still escrow funds to be returned, i.e., there must still be unsettled orders. This check will mean that by the time `close_market` is called there can be non-settled orders. At least all winnings should have been paid out.
2. Throw an error if an order that is attempted to be closed is not yet complete, i.e., settled or cancelled. 

Ideally `close_market` could be restricted while there still are dependent accounts open but I don't thinkthis is possible with the current data model. E.g., be sure all cancelled orders are closed first. 