### PR TITLE
Fix: close escrow as part of `close_market` 

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -697,7 +697,7 @@ pub struct CloseMarket<'info> {
         seeds = [b"escrow".as_ref(), market.key().as_ref()],
         bump,
     )]
-    pub market_escrow: Box<Account<'info, TokenAccount>>,
+    pub market_escrow: Account<'info, TokenAccount>,
 
     #[account(mut)]
     pub authority: SystemAccount<'info>,

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -690,6 +690,15 @@ pub struct CloseMarket<'info> {
         close = authority,
     )]
     pub market: Account<'info, Market>,
+    #[account(
+        mut,
+        token::mint = market.mint_account,
+        token::authority = market_escrow,
+        seeds = [b"escrow".as_ref(), market.key().as_ref()],
+        bump,
+    )]
+    pub market_escrow: Box<Account<'info, TokenAccount>>,
+
     #[account(mut)]
     pub authority: SystemAccount<'info>,
 
@@ -697,4 +706,7 @@ pub struct CloseMarket<'info> {
     pub crank_operator: Signer<'info>,
     #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
     pub authorised_operators: Account<'info, AuthorisedOperators>,
+
+    #[account(address = anchor_spl::token::ID)]
+    pub token_program: Program<'info, Token>,
 }

--- a/programs/monaco_protocol/src/instructions/market/escrow.rs
+++ b/programs/monaco_protocol/src/instructions/market/escrow.rs
@@ -1,0 +1,22 @@
+use anchor_lang::prelude::*;
+
+use crate::context::CloseMarket;
+use anchor_lang::context::{Context, CpiContext};
+use anchor_lang::{Key, ToAccountInfo};
+use anchor_spl::token;
+
+pub fn close_escrow_token_account(ctx: &Context<CloseMarket>) -> Result<()> {
+    token::close_account(CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        token::CloseAccount {
+            account: ctx.accounts.market_escrow.to_account_info(),
+            destination: ctx.accounts.authority.to_account_info(),
+            authority: ctx.accounts.market_escrow.to_account_info(),
+        },
+        &[&[
+            "escrow".as_ref(),
+            ctx.accounts.market.key().as_ref(),
+            &[ctx.accounts.market.escrow_account_bump],
+        ]],
+    ))
+}

--- a/programs/monaco_protocol/src/instructions/market/mod.rs
+++ b/programs/monaco_protocol/src/instructions/market/mod.rs
@@ -1,10 +1,12 @@
 mod create_market;
+mod escrow;
 mod market_authority;
 mod update_market_locktime;
 mod update_market_status;
 mod update_market_title;
 
 pub use create_market::*;
+pub use escrow::*;
 pub use market_authority::*;
 pub use update_market_locktime::*;
 pub use update_market_status::*;

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -530,6 +530,8 @@ pub mod monaco_protocol {
             CoreError::MarketNotReadyToClose
         );
 
+        instructions::market::close_escrow_token_account(&ctx)?;
+
         Ok(())
     }
 }

--- a/tests/protocol/close_market.ts
+++ b/tests/protocol/close_market.ts
@@ -46,10 +46,24 @@ describe("Close market accounts", () => {
 
     const balanceAfterMarketClosed =
       await monaco.provider.connection.getBalance(marketOperator.publicKey);
+
+    // ensure rent has been returned
     const expectedBalanceAfterMarketClosed =
       balanceMarketCreated + marketRent + escrowRent;
-
     assert.equal(balanceAfterMarketClosed, expectedBalanceAfterMarketClosed);
+
+    await monaco.program.account.market.fetch(market.pk).catch((e) => {
+      assert.equal(e.message, `Account does not exist ${market.pk.toBase58()}`);
+    });
+
+    await monaco.provider.connection
+      .getAccountInfo(market.escrowPk)
+      .catch((e) => {
+        assert.equal(
+          e.message,
+          `Account does not exist ${market.escrowPk.toBase58()}`,
+        );
+      });
   });
 
   it("close market: market incorrect status", async () => {

--- a/tests/protocol/close_market.ts
+++ b/tests/protocol/close_market.ts
@@ -28,11 +28,15 @@ describe("Close market accounts", () => {
     await market.readyToClose();
 
     const marketRent = await monaco.provider.connection.getBalance(market.pk);
+    const escrowRent = await monaco.provider.connection.getBalance(
+      market.escrowPk,
+    );
 
     await monaco.program.methods
       .closeMarket()
       .accounts({
         market: market.pk,
+        marketEscrow: market.escrowPk,
         authority: marketOperator.publicKey,
         authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         crankOperator: monaco.operatorPk,
@@ -42,7 +46,8 @@ describe("Close market accounts", () => {
 
     const balanceAfterMarketClosed =
       await monaco.provider.connection.getBalance(marketOperator.publicKey);
-    const expectedBalanceAfterMarketClosed = balanceMarketCreated + marketRent;
+    const expectedBalanceAfterMarketClosed =
+      balanceMarketCreated + marketRent + escrowRent;
 
     assert.equal(balanceAfterMarketClosed, expectedBalanceAfterMarketClosed);
   });
@@ -68,6 +73,7 @@ describe("Close market accounts", () => {
       .closeMarket()
       .accounts({
         market: market.pk,
+        marketEscrow: market.escrowPk,
         authority: marketOperator.publicKey,
         authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         crankOperator: monaco.operatorPk,
@@ -100,6 +106,7 @@ describe("Close market accounts", () => {
       .closeMarket()
       .accounts({
         market: market.pk,
+        marketEscrow: market.escrowPk,
         authority: monaco.operatorPk,
         authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         crankOperator: monaco.operatorPk,
@@ -142,6 +149,7 @@ describe("Close market accounts", () => {
       .closeMarket()
       .accounts({
         market: marketB.pk,
+        marketEscrow: marketB.escrowPk,
         authority: marketOperator.publicKey,
         authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         crankOperator: monaco.operatorPk,


### PR DESCRIPTION
As part of the `close_market` instruction we should also close the `market_escrow` token account.

This closure is done slightly differently as the account is still owned by the `token_program` so needs to be closed via a CPI (the authority is a PDA owned by the monaco program but it is not the owner).