### PR TITLE
fix!: client type wrappers for enums that anchor returns

### DIFF
--- a/admin/leaderboard/market_leaderboard.ts
+++ b/admin/leaderboard/market_leaderboard.ts
@@ -2,7 +2,7 @@ import {
   AccountData,
   Order,
   Orders,
-  OrderStatus,
+  OrderStatusFilter,
   MarketAccount,
 } from "../../npm-client/src";
 import { checkEnumValue, fetchTokenData, numberAsPnlString } from "./util";
@@ -23,10 +23,10 @@ export async function getLeaderboardPerMarket() {
 
   // get all orders for settled markets
   const winningOrdersResponse = await new Orders(program)
-    .filterByStatus(OrderStatus.SettledWin)
+    .filterByStatus(OrderStatusFilter.SettledWin)
     .fetch();
   const losingOrdersResponse = await new Orders(program)
-    .filterByStatus(OrderStatus.SettledLose)
+    .filterByStatus(OrderStatusFilter.SettledLose)
     .fetch();
 
   const winningOrders = winningOrdersResponse.data.orderAccounts;

--- a/admin/leaderboard/market_leaderboard.ts
+++ b/admin/leaderboard/market_leaderboard.ts
@@ -5,7 +5,7 @@ import {
   OrderStatusFilter,
   MarketAccount,
 } from "../../npm-client/src";
-import { checkEnumValue, fetchTokenData, numberAsPnlString } from "./util";
+import { fetchTokenData, numberAsPnlString } from "./util";
 import { KNOWN_WALLETS } from "./data";
 import { getProtocolProgram } from "../util";
 
@@ -108,10 +108,10 @@ function constructMarketLeaderboard(
       const orderMatchedStake = stake - voidedStake;
       totalStakeMatched += orderMatchedStake;
 
-      if (checkEnumValue(order.orderStatus, "settledWin")) {
+      if (order.orderStatus.settledWin) {
         winCount += 1;
         totalStakeReturn += payout;
-      } else if (checkEnumValue(order.orderStatus, "settledLose")) {
+      } else if (order.orderStatus.settledLose) {
         lossCount += 1;
         totalStakeReturn -= orderMatchedStake;
       }

--- a/admin/leaderboard/util.ts
+++ b/admin/leaderboard/util.ts
@@ -43,7 +43,3 @@ export function numberAsPnlString(value: number) {
   }
   return value > 0 ? `+${value.toFixed(2)}` : `${value.toFixed(2)}`;
 }
-
-export function checkEnumValue(value: any, jsonKey: string) {
-  return Object.prototype.hasOwnProperty.call(value, jsonKey);
-}

--- a/npm-admin-client/docs/types/markets.md
+++ b/npm-admin-client/docs/types/markets.md
@@ -22,19 +22,25 @@
 *   [BatchAddPricesToOutcomesResponse][18]
     *   [Properties][19]
 *   [MarketStatus][20]
-*   [MarketAccount][21]
-    *   [Properties][22]
-*   [EpochTimeStamp][23]
+    *   [initializing][21]
+    *   [open][22]
+    *   [locked][23]
+    *   [readyForSettlement][24]
+    *   [settled][25]
+    *   [readyToClose][26]
+*   [MarketAccount][27]
+    *   [Properties][28]
+*   [EpochTimeStamp][29]
 
 ## CreateMarketResponse
 
-Type: {marketPk: PublicKey, tnxId: [string][24], market: [MarketAccount][21]}
+Type: {marketPk: PublicKey, tnxId: [string][30], market: [MarketAccount][27]}
 
 ### Properties
 
 *   `marketPk` **PublicKey**&#x20;
-*   `tnxId` **[string][24]**&#x20;
-*   `market` **[MarketAccount][21]**&#x20;
+*   `tnxId` **[string][30]**&#x20;
+*   `market` **[MarketAccount][27]**&#x20;
 
 ## CreateMarketWithOutcomesAndPriceLadderResponse
 
@@ -42,11 +48,11 @@ Type: any
 
 ## OutcomePdaResponse
 
-Type: {outcomeIndex: [number][25], outcomePda: PublicKey}
+Type: {outcomeIndex: [number][31], outcomePda: PublicKey}
 
 ### Properties
 
-*   `outcomeIndex` **[number][25]**&#x20;
+*   `outcomeIndex` **[number][31]**&#x20;
 *   `outcomePda` **PublicKey**&#x20;
 
 ## OutcomeInitialisationResponse
@@ -59,81 +65,105 @@ Type: any
 
 ## OutcomePdasResponse
 
-Type: {outcomePdas: [Array][26]<[OutcomePdaResponse][4]>}
+Type: {outcomePdas: [Array][32]<[OutcomePdaResponse][4]>}
 
 ### Properties
 
-*   `outcomePdas` **[Array][26]<[OutcomePdaResponse][4]>**&#x20;
+*   `outcomePdas` **[Array][32]<[OutcomePdaResponse][4]>**&#x20;
 
 ## OutcomeInitialisationsResponse
 
-Type: {outcomes: [Array][26]<[OutcomeInitialisationResponse][6]>}
+Type: {outcomes: [Array][32]<[OutcomeInitialisationResponse][6]>}
 
 ### Properties
 
-*   `outcomes` **[Array][26]<[OutcomeInitialisationResponse][6]>**&#x20;
+*   `outcomes` **[Array][32]<[OutcomeInitialisationResponse][6]>**&#x20;
 
 ## AddPricesToOutcomeResponse
 
-Type: {priceLadder: [Array][26]<[number][25]>, tnxId: [string][24]}
+Type: {priceLadder: [Array][32]<[number][31]>, tnxId: [string][30]}
 
 ### Properties
 
-*   `priceLadder` **[Array][26]<[number][25]>**&#x20;
-*   `tnxId` **[string][24]**&#x20;
+*   `priceLadder` **[Array][32]<[number][31]>**&#x20;
+*   `tnxId` **[string][30]**&#x20;
 
 ## BatchAddPricesToOutcomeResponse
 
-Type: {batches: [Array][26]<[AddPricesToOutcomeResponse][12]>}
+Type: {batches: [Array][32]<[AddPricesToOutcomeResponse][12]>}
 
 ### Properties
 
-*   `batches` **[Array][26]<[AddPricesToOutcomeResponse][12]>**&#x20;
+*   `batches` **[Array][32]<[AddPricesToOutcomeResponse][12]>**&#x20;
 
 ## BatchAddPricesToOutcomes
 
-Type: {outcomeIndex: [number][25], outcomePda: PublicKey, batches: [Array][26]<[AddPricesToOutcomeResponse][12]>}
+Type: {outcomeIndex: [number][31], outcomePda: PublicKey, batches: [Array][32]<[AddPricesToOutcomeResponse][12]>}
 
 ### Properties
 
-*   `outcomeIndex` **[number][25]**&#x20;
+*   `outcomeIndex` **[number][31]**&#x20;
 *   `outcomePda` **PublicKey**&#x20;
-*   `batches` **[Array][26]<[AddPricesToOutcomeResponse][12]>**&#x20;
+*   `batches` **[Array][32]<[AddPricesToOutcomeResponse][12]>**&#x20;
 
 ## BatchAddPricesToOutcomesResponse
 
-Type: {results: [Array][26]<[BatchAddPricesToOutcomes][16]>}
+Type: {results: [Array][32]<[BatchAddPricesToOutcomes][16]>}
 
 ### Properties
 
-*   `results` **[Array][26]<[BatchAddPricesToOutcomes][16]>**&#x20;
+*   `results` **[Array][32]<[BatchAddPricesToOutcomes][16]>**&#x20;
 
 ## MarketStatus
 
+### initializing
+
+Type: Record<[string][30], never>
+
+### open
+
+Type: Record<[string][30], never>
+
+### locked
+
+Type: Record<[string][30], never>
+
+### readyForSettlement
+
+Type: Record<[string][30], never>
+
+### settled
+
+Type: Record<[string][30], never>
+
+### readyToClose
+
+Type: Record<[string][30], never>
+
 ## MarketAccount
 
-Type: {authority: BN, decimalLimit: [number][25], escrowAccountBump: [number][25], eventAccount: PublicKey, marketLockTimestamp: BN, marketOutcomesCount: [number][25], marketSettleTimestamp: null?, marketStatus: [MarketStatus][20], marketType: [string][24], marketWinningOutcomeIndex: [number][25]?, mintAccount: PublicKey, published: [boolean][27], suspended: [boolean][27], title: [string][24]}
+Type: {authority: BN, decimalLimit: [number][31], escrowAccountBump: [number][31], eventAccount: PublicKey, marketLockTimestamp: BN, marketOutcomesCount: [number][31], marketSettleTimestamp: null?, marketStatus: [MarketStatus][20], marketType: [string][30], marketWinningOutcomeIndex: [number][31]?, mintAccount: PublicKey, published: [boolean][33], suspended: [boolean][33], title: [string][30]}
 
 ### Properties
 
 *   `authority` **BN**&#x20;
-*   `decimalLimit` **[number][25]**&#x20;
-*   `escrowAccountBump` **[number][25]**&#x20;
+*   `decimalLimit` **[number][31]**&#x20;
+*   `escrowAccountBump` **[number][31]**&#x20;
 *   `eventAccount` **PublicKey**&#x20;
 *   `marketLockTimestamp` **BN**&#x20;
-*   `marketOutcomesCount` **[number][25]**&#x20;
+*   `marketOutcomesCount` **[number][31]**&#x20;
 *   `marketSettleTimestamp` **null?**&#x20;
 *   `marketStatus` **[MarketStatus][20]**&#x20;
-*   `marketType` **[string][24]**&#x20;
-*   `marketWinningOutcomeIndex` **[number][25]?**&#x20;
+*   `marketType` **[string][30]**&#x20;
+*   `marketWinningOutcomeIndex` **[number][31]?**&#x20;
 *   `mintAccount` **PublicKey**&#x20;
-*   `published` **[boolean][27]**&#x20;
-*   `suspended` **[boolean][27]**&#x20;
-*   `title` **[string][24]**&#x20;
+*   `published` **[boolean][33]**&#x20;
+*   `suspended` **[boolean][33]**&#x20;
+*   `title` **[string][30]**&#x20;
 
 ## EpochTimeStamp
 
-Type: [number][25]
+Type: [number][31]
 
 [1]: #createmarketresponse
 
@@ -175,16 +205,28 @@ Type: [number][25]
 
 [20]: #marketstatus
 
-[21]: #marketaccount
+[21]: #initializing
 
-[22]: #properties-8
+[22]: #open
 
-[23]: #epochtimestamp
+[23]: #locked
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[24]: #readyforsettlement
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[25]: #settled
 
-[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[26]: #readytoclose
 
-[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[27]: #marketaccount
+
+[28]: #properties-8
+
+[29]: #epochtimestamp
+
+[30]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean

--- a/npm-admin-client/types/markets.ts
+++ b/npm-admin-client/types/markets.ts
@@ -54,12 +54,13 @@ export type BatchAddPricesToOutcomesResponse = {
 
 // Duplicates from primary client
 
-export enum MarketStatus {
-  Open = 0x00,
-  Locked = 0x01,
-  ReadyForSettlement = 0x02,
-  Settled = 0x03,
-  Complete = 0x04,
+export class MarketStatus {
+  initializing?: Record<string, never>;
+  open?: Record<string, never>;
+  locked?: Record<string, never>;
+  readyForSettlement?: Record<string, never>;
+  settled?: Record<string, never>;
+  readyToClose?: Record<string, never>;
 }
 
 export type MarketAccount = {

--- a/npm-client/docs/endpoints/cancel_order.md
+++ b/npm-client/docs/endpoints/cancel_order.md
@@ -13,7 +13,7 @@
 
 For the provided order publicKey, cancel the order if the program provider owns the order.Orders can be cancelled if they:
 
-*   Have the status of OrderStatus.OPEN
+*   Have the status of OPEN
 *   Are partially matched (only unmatched stake will be cancelled)
 
 ### Parameters
@@ -34,7 +34,7 @@ Returns **CancelOrderResponse** the provided order publicKey and the transaction
 
 For the provided market publicKey, attempt to cancel all cancellable orders owned by the program provider wallet. Orders can be cancelled if they:
 
-*   Have the status of OrderStatus.OPEN
+*   Have the status of OPEN
 *   Are partially matched (only unmatched stake will be cancelled)
 
 ### Parameters

--- a/npm-client/docs/endpoints/market_query.md
+++ b/npm-client/docs/endpoints/market_query.md
@@ -2,16 +2,19 @@
 
 ### Table of Contents
 
-*   [Markets][1]
-*   [getMarketAccountsByStatus][2]
-    *   [Parameters][3]
-    *   [Examples][4]
-*   [getMarketAccountsByEvent][5]
-    *   [Parameters][6]
-    *   [Examples][7]
-*   [getMarketAccountsByStatusAndMintAccount][8]
-    *   [Parameters][9]
-    *   [Examples][10]
+*   [MarketStatusFilter][1]
+*   [Markets][2]
+*   [getMarketAccountsByStatus][3]
+    *   [Parameters][4]
+    *   [Examples][5]
+*   [getMarketAccountsByEvent][6]
+    *   [Parameters][7]
+    *   [Examples][8]
+*   [getMarketAccountsByStatusAndMintAccount][9]
+    *   [Parameters][10]
+    *   [Examples][11]
+
+## MarketStatusFilter
 
 ## Markets
 
@@ -22,12 +25,12 @@ Get all market accounts for the provided market status.
 ### Parameters
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
-*   `status` **MarketStatus** {MarketStatus} status of the market, provided by the MarketStatus enum
+*   `status` **[MarketStatusFilter][1]** {MarketStatusFilter} status of the market, provided by the MarketStatusFilter enum
 
 ### Examples
 
 ```javascript
-const status = MarketStatus.Open
+const status = MarketStatusFilter.Open
 const marketAccounts = await getMarketAccountsByStatus(program, status)
 ```
 
@@ -58,35 +61,37 @@ Get all market accounts for the provided market status and mint account.
 ### Parameters
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
-*   `status` **MarketStatus** {MarketStatus} status of the market, provided by the MarketStatus enum
+*   `status` **[MarketStatusFilter][1]** {MarketStatusFilter} status of the market, provided by the MarketStatusFilter enum
 *   `mintAccount` **PublicKey** {PublicKey} publicKey of the mint account
 
 ### Examples
 
 ```javascript
-const status = MarketStatus.Open
+const status = MarketStatusFilter.Open
 const mintAccount = new PublicKey("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU")
 const marketAccounts = await getMarketAccountsByStatusAndMintAccount(program, status, mintAccount)
 ```
 
 Returns **MarketAccounts** fetched market accounts mapped to their publicKey
 
-[1]: #markets
+[1]: #marketstatusfilter
 
-[2]: #getmarketaccountsbystatus
+[2]: #markets
 
-[3]: #parameters
+[3]: #getmarketaccountsbystatus
 
-[4]: #examples
+[4]: #parameters
 
-[5]: #getmarketaccountsbyevent
+[5]: #examples
 
-[6]: #parameters-1
+[6]: #getmarketaccountsbyevent
 
-[7]: #examples-1
+[7]: #parameters-1
 
-[8]: #getmarketaccountsbystatusandmintaccount
+[8]: #examples-1
 
-[9]: #parameters-2
+[9]: #getmarketaccountsbystatusandmintaccount
 
-[10]: #examples-2
+[10]: #parameters-2
+
+[11]: #examples-2

--- a/npm-client/docs/endpoints/order_query.md
+++ b/npm-client/docs/endpoints/order_query.md
@@ -2,21 +2,24 @@
 
 ### Table of Contents
 
-*   [Orders][1]
-    *   [Parameters][2]
-    *   [Examples][3]
-*   [getOrdersByStatusForProviderWallet][4]
-    *   [Parameters][5]
-    *   [Examples][6]
-*   [getOrdersByMarketForProviderWallet][7]
-    *   [Parameters][8]
-    *   [Examples][9]
-*   [getCancellableOrdersByMarketForProviderWallet][10]
-    *   [Parameters][11]
-    *   [Examples][12]
-*   [getOrdersByEventForProviderWallet][13]
-    *   [Parameters][14]
-    *   [Examples][15]
+*   [OrderStatusFilter][1]
+*   [Orders][2]
+    *   [Parameters][3]
+    *   [Examples][4]
+*   [getOrdersByStatusForProviderWallet][5]
+    *   [Parameters][6]
+    *   [Examples][7]
+*   [getOrdersByMarketForProviderWallet][8]
+    *   [Parameters][9]
+    *   [Examples][10]
+*   [getCancellableOrdersByMarketForProviderWallet][11]
+    *   [Parameters][12]
+    *   [Examples][13]
+*   [getOrdersByEventForProviderWallet][14]
+    *   [Parameters][15]
+    *   [Examples][16]
+
+## OrderStatusFilter
 
 ## Orders
 
@@ -40,7 +43,7 @@ const purchaserPk = new PublicKey('5BZWY6XWPxuWFxs2jagkmUkCoBWmJ6c4YEArr83hYBWk'
 const orders = await Orders.orderQuery(program)
       .filterByMarket(marketPk)
       .filterByPurchaser(purchaserPk)
-      .filterByStatus(OrderStatus.Open)
+      .filterByStatus(OrderStatusFilter.Open)
       .fetch();
 
 // Returns all open order accounts for the specified market and purchasing wallet.
@@ -53,12 +56,12 @@ Get all orders owned by the program provider wallet - by order status
 ### Parameters
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
-*   `status` **OrderStatus** {orderStatus} status of the order, provided by the orderStatus enum
+*   `status` **[OrderStatusFilter][1]** {orderStatus} status of the order, provided by the orderStatus enum
 
 ### Examples
 
 ```javascript
-const status = OrderStatus.Open
+const status = OrderStatusFilter.Open
 const orders = await getOrdersByStatusForProviderWallet(program, status)
 ```
 
@@ -86,7 +89,7 @@ Returns **OrderAccounts** fetched order accounts mapped to their publicKey
 
 Get all cancellable orders owned by the program provider for the given market. Orders can be cancelled if they:
 
-*   Have the status of OrderStatus.OPEN
+*   Have the status of OPEN
 *   Are partially matched (only unmatched stake will be cancelled)
 
 ### Parameters
@@ -121,32 +124,34 @@ const orders = await getOrdersByEventForProviderWallet(program, eventPk)
 
 Returns **OrderAccounts** fetched order accounts mapped to their publicKey
 
-[1]: #orders
+[1]: #orderstatusfilter
 
-[2]: #parameters
+[2]: #orders
 
-[3]: #examples
+[3]: #parameters
 
-[4]: #getordersbystatusforproviderwallet
+[4]: #examples
 
-[5]: #parameters-1
+[5]: #getordersbystatusforproviderwallet
 
-[6]: #examples-1
+[6]: #parameters-1
 
-[7]: #getordersbymarketforproviderwallet
+[7]: #examples-1
 
-[8]: #parameters-2
+[8]: #getordersbymarketforproviderwallet
 
-[9]: #examples-2
+[9]: #parameters-2
 
-[10]: #getcancellableordersbymarketforproviderwallet
+[10]: #examples-2
 
-[11]: #parameters-3
+[11]: #getcancellableordersbymarketforproviderwallet
 
-[12]: #examples-3
+[12]: #parameters-3
 
-[13]: #getordersbyeventforproviderwallet
+[13]: #examples-3
 
-[14]: #parameters-4
+[14]: #getordersbyeventforproviderwallet
 
-[15]: #examples-4
+[15]: #parameters-4
+
+[16]: #examples-4

--- a/npm-client/docs/types/order.md
+++ b/npm-client/docs/types/order.md
@@ -3,130 +3,105 @@
 ### Table of Contents
 
 *   [OrderStatus][1]
-    *   [open][2]
-    *   [matched][3]
-    *   [settledWin][4]
-    *   [settledLose][5]
-    *   [cancelled][6]
-*   [Match][7]
-    *   [Properties][8]
-*   [Order][9]
-    *   [Properties][10]
-*   [PendingOrders][11]
-    *   [Properties][12]
-*   [OrderAccounts][13]
-    *   [Properties][14]
-*   [CreateOrderResponse][15]
-    *   [Properties][16]
-*   [CancelOrderResponse][17]
-    *   [Properties][18]
-*   [CancelOrdersResponse][19]
-    *   [Properties][20]
-*   [orderPdaResponse][21]
-    *   [Properties][22]
-*   [StakeInteger][23]
-    *   [Properties][24]
+*   [Match][2]
+    *   [Properties][3]
+*   [Order][4]
+    *   [Properties][5]
+*   [PendingOrders][6]
+    *   [Properties][7]
+*   [OrderAccounts][8]
+    *   [Properties][9]
+*   [CreateOrderResponse][10]
+    *   [Properties][11]
+*   [CancelOrderResponse][12]
+    *   [Properties][13]
+*   [CancelOrdersResponse][14]
+    *   [Properties][15]
+*   [orderPdaResponse][16]
+    *   [Properties][17]
+*   [StakeInteger][18]
+    *   [Properties][19]
 
 ## OrderStatus
 
-### open
-
-Type: Record<[string][25], never>
-
-### matched
-
-Type: Record<[string][25], never>
-
-### settledWin
-
-Type: Record<[string][25], never>
-
-### settledLose
-
-Type: Record<[string][25], never>
-
-### cancelled
-
-Type: Record<[string][25], never>
-
 ## Match
 
-Type: {price: [number][26], stake: [number][26]}
+Type: {price: [number][20], stake: [number][20]}
 
 ### Properties
 
-*   `price` **[number][26]**&#x20;
-*   `stake` **[number][26]**&#x20;
+*   `price` **[number][20]**&#x20;
+*   `stake` **[number][20]**&#x20;
 
 ## Order
 
-Type: {purchaser: PublicKey, market: PublicKey, marketOutcomeIndex: [number][26], forOutcome: [boolean][27], orderStatus: [OrderStatus][1], stake: BN, voidedStake: BN, expectedPrice: [number][26], creationTimestamp: BN, stakeUnmatched: BN, payout: BN}
+Type: {purchaser: PublicKey, market: PublicKey, marketOutcomeIndex: [number][20], forOutcome: [boolean][21], orderStatus: [OrderStatus][1], stake: BN, voidedStake: BN, expectedPrice: [number][20], creationTimestamp: BN, stakeUnmatched: BN, payout: BN}
 
 ### Properties
 
 *   `purchaser` **PublicKey**&#x20;
 *   `market` **PublicKey**&#x20;
-*   `marketOutcomeIndex` **[number][26]**&#x20;
-*   `forOutcome` **[boolean][27]**&#x20;
+*   `marketOutcomeIndex` **[number][20]**&#x20;
+*   `forOutcome` **[boolean][21]**&#x20;
 *   `orderStatus` **[OrderStatus][1]**&#x20;
 *   `stake` **BN**&#x20;
 *   `voidedStake` **BN**&#x20;
-*   `expectedPrice` **[number][26]**&#x20;
+*   `expectedPrice` **[number][20]**&#x20;
 *   `creationTimestamp` **BN**&#x20;
 *   `stakeUnmatched` **BN**&#x20;
 *   `payout` **BN**&#x20;
 
 ## PendingOrders
 
-Type: {pendingOrders: [Array][28]\<GetAccount<[Order][9]>>}
+Type: {pendingOrders: [Array][22]\<GetAccount<[Order][4]>>}
 
 ### Properties
 
-*   `pendingOrders` **[Array][28]\<GetAccount<[Order][9]>>**&#x20;
+*   `pendingOrders` **[Array][22]\<GetAccount<[Order][4]>>**&#x20;
 
 ## OrderAccounts
 
-Type: {orderAccounts: [Array][28]\<GetAccount<[Order][9]>>}
+Type: {orderAccounts: [Array][22]\<GetAccount<[Order][4]>>}
 
 ### Properties
 
-*   `orderAccounts` **[Array][28]\<GetAccount<[Order][9]>>**&#x20;
+*   `orderAccounts` **[Array][22]\<GetAccount<[Order][4]>>**&#x20;
 
 ## CreateOrderResponse
 
-Type: {orderPk: PublicKey, tnxID: ([string][25] | void)}
+Type: {orderPk: PublicKey, tnxID: ([string][23] | void)}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `tnxID` **([string][25] | void)**&#x20;
+*   `tnxID` **([string][23] | void)**&#x20;
 
 ## CancelOrderResponse
 
-Type: {orderPk: PublicKey, tnxID: [string][25]}
+Type: {orderPk: PublicKey, tnxID: [string][23]}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `tnxID` **[string][25]**&#x20;
+*   `tnxID` **[string][23]**&#x20;
 
 ## CancelOrdersResponse
 
-Type: {failedCancellationOrders: [Array][28]\<PublicKey>, tnxIDs: [Array][28]<[string][25]>}
+Type: {failedCancellationOrders: [Array][22]\<PublicKey>, tnxIDs: [Array][22]<[string][23]>}
 
 ### Properties
 
-*   `failedCancellationOrders` **[Array][28]\<PublicKey>**&#x20;
-*   `tnxIDs` **[Array][28]<[string][25]>**&#x20;
+*   `failedCancellationOrders` **[Array][22]\<PublicKey>**&#x20;
+*   `tnxIDs` **[Array][22]<[string][23]>**&#x20;
 
 ## orderPdaResponse
 
-Type: {orderPk: PublicKey, distinctSeed: [string][25]}
+Type: {orderPk: PublicKey, distinctSeed: [string][23]}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `distinctSeed` **[string][25]**&#x20;
+*   `distinctSeed` **[string][23]**&#x20;
 
 ## StakeInteger
 
@@ -138,56 +113,46 @@ Type: {stakeInteger: BN}
 
 [1]: #orderstatus
 
-[2]: #open
+[2]: #match
 
-[3]: #matched
+[3]: #properties
 
-[4]: #settledwin
+[4]: #order
 
-[5]: #settledlose
+[5]: #properties-1
 
-[6]: #cancelled
+[6]: #pendingorders
 
-[7]: #match
+[7]: #properties-2
 
-[8]: #properties
+[8]: #orderaccounts
 
-[9]: #order
+[9]: #properties-3
 
-[10]: #properties-1
+[10]: #createorderresponse
 
-[11]: #pendingorders
+[11]: #properties-4
 
-[12]: #properties-2
+[12]: #cancelorderresponse
 
-[13]: #orderaccounts
+[13]: #properties-5
 
-[14]: #properties-3
+[14]: #cancelordersresponse
 
-[15]: #createorderresponse
+[15]: #properties-6
 
-[16]: #properties-4
+[16]: #orderpdaresponse
 
-[17]: #cancelorderresponse
+[17]: #properties-7
 
-[18]: #properties-5
+[18]: #stakeinteger
 
-[19]: #cancelordersresponse
+[19]: #properties-8
 
-[20]: #properties-6
+[20]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[21]: #orderpdaresponse
+[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[22]: #properties-7
+[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[23]: #stakeinteger
-
-[24]: #properties-8
-
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-
-[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-
-[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
-
-[28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/npm-client/docs/types/order.md
+++ b/npm-client/docs/types/order.md
@@ -3,105 +3,130 @@
 ### Table of Contents
 
 *   [OrderStatus][1]
-*   [Match][2]
-    *   [Properties][3]
-*   [Order][4]
-    *   [Properties][5]
-*   [PendingOrders][6]
-    *   [Properties][7]
-*   [OrderAccounts][8]
-    *   [Properties][9]
-*   [CreateOrderResponse][10]
-    *   [Properties][11]
-*   [CancelOrderResponse][12]
-    *   [Properties][13]
-*   [CancelOrdersResponse][14]
-    *   [Properties][15]
-*   [orderPdaResponse][16]
-    *   [Properties][17]
-*   [StakeInteger][18]
-    *   [Properties][19]
+    *   [open][2]
+    *   [matched][3]
+    *   [settledWin][4]
+    *   [settledLose][5]
+    *   [cancelled][6]
+*   [Match][7]
+    *   [Properties][8]
+*   [Order][9]
+    *   [Properties][10]
+*   [PendingOrders][11]
+    *   [Properties][12]
+*   [OrderAccounts][13]
+    *   [Properties][14]
+*   [CreateOrderResponse][15]
+    *   [Properties][16]
+*   [CancelOrderResponse][17]
+    *   [Properties][18]
+*   [CancelOrdersResponse][19]
+    *   [Properties][20]
+*   [orderPdaResponse][21]
+    *   [Properties][22]
+*   [StakeInteger][23]
+    *   [Properties][24]
 
 ## OrderStatus
 
+### open
+
+Type: Record<[string][25], never>
+
+### matched
+
+Type: Record<[string][25], never>
+
+### settledWin
+
+Type: Record<[string][25], never>
+
+### settledLose
+
+Type: Record<[string][25], never>
+
+### cancelled
+
+Type: Record<[string][25], never>
+
 ## Match
 
-Type: {price: [number][20], stake: [number][20]}
+Type: {price: [number][26], stake: [number][26]}
 
 ### Properties
 
-*   `price` **[number][20]**&#x20;
-*   `stake` **[number][20]**&#x20;
+*   `price` **[number][26]**&#x20;
+*   `stake` **[number][26]**&#x20;
 
 ## Order
 
-Type: {purchaser: PublicKey, market: PublicKey, marketOutcomeIndex: [number][20], forOutcome: [boolean][21], orderStatus: [OrderStatus][1], stake: BN, voidedStake: BN, expectedPrice: [number][20], creationTimestamp: BN, stakeUnmatched: BN, payout: BN}
+Type: {purchaser: PublicKey, market: PublicKey, marketOutcomeIndex: [number][26], forOutcome: [boolean][27], orderStatus: [OrderStatus][1], stake: BN, voidedStake: BN, expectedPrice: [number][26], creationTimestamp: BN, stakeUnmatched: BN, payout: BN}
 
 ### Properties
 
 *   `purchaser` **PublicKey**&#x20;
 *   `market` **PublicKey**&#x20;
-*   `marketOutcomeIndex` **[number][20]**&#x20;
-*   `forOutcome` **[boolean][21]**&#x20;
+*   `marketOutcomeIndex` **[number][26]**&#x20;
+*   `forOutcome` **[boolean][27]**&#x20;
 *   `orderStatus` **[OrderStatus][1]**&#x20;
 *   `stake` **BN**&#x20;
 *   `voidedStake` **BN**&#x20;
-*   `expectedPrice` **[number][20]**&#x20;
+*   `expectedPrice` **[number][26]**&#x20;
 *   `creationTimestamp` **BN**&#x20;
 *   `stakeUnmatched` **BN**&#x20;
 *   `payout` **BN**&#x20;
 
 ## PendingOrders
 
-Type: {pendingOrders: [Array][22]\<GetAccount<[Order][4]>>}
+Type: {pendingOrders: [Array][28]\<GetAccount<[Order][9]>>}
 
 ### Properties
 
-*   `pendingOrders` **[Array][22]\<GetAccount<[Order][4]>>**&#x20;
+*   `pendingOrders` **[Array][28]\<GetAccount<[Order][9]>>**&#x20;
 
 ## OrderAccounts
 
-Type: {orderAccounts: [Array][22]\<GetAccount<[Order][4]>>}
+Type: {orderAccounts: [Array][28]\<GetAccount<[Order][9]>>}
 
 ### Properties
 
-*   `orderAccounts` **[Array][22]\<GetAccount<[Order][4]>>**&#x20;
+*   `orderAccounts` **[Array][28]\<GetAccount<[Order][9]>>**&#x20;
 
 ## CreateOrderResponse
 
-Type: {orderPk: PublicKey, tnxID: ([string][23] | void)}
+Type: {orderPk: PublicKey, tnxID: ([string][25] | void)}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `tnxID` **([string][23] | void)**&#x20;
+*   `tnxID` **([string][25] | void)**&#x20;
 
 ## CancelOrderResponse
 
-Type: {orderPk: PublicKey, tnxID: [string][23]}
+Type: {orderPk: PublicKey, tnxID: [string][25]}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `tnxID` **[string][23]**&#x20;
+*   `tnxID` **[string][25]**&#x20;
 
 ## CancelOrdersResponse
 
-Type: {failedCancellationOrders: [Array][22]\<PublicKey>, tnxIDs: [Array][22]<[string][23]>}
+Type: {failedCancellationOrders: [Array][28]\<PublicKey>, tnxIDs: [Array][28]<[string][25]>}
 
 ### Properties
 
-*   `failedCancellationOrders` **[Array][22]\<PublicKey>**&#x20;
-*   `tnxIDs` **[Array][22]<[string][23]>**&#x20;
+*   `failedCancellationOrders` **[Array][28]\<PublicKey>**&#x20;
+*   `tnxIDs` **[Array][28]<[string][25]>**&#x20;
 
 ## orderPdaResponse
 
-Type: {orderPk: PublicKey, distinctSeed: [string][23]}
+Type: {orderPk: PublicKey, distinctSeed: [string][25]}
 
 ### Properties
 
 *   `orderPk` **PublicKey**&#x20;
-*   `distinctSeed` **[string][23]**&#x20;
+*   `distinctSeed` **[string][25]**&#x20;
 
 ## StakeInteger
 
@@ -113,46 +138,56 @@ Type: {stakeInteger: BN}
 
 [1]: #orderstatus
 
-[2]: #match
+[2]: #open
 
-[3]: #properties
+[3]: #matched
 
-[4]: #order
+[4]: #settledwin
 
-[5]: #properties-1
+[5]: #settledlose
 
-[6]: #pendingorders
+[6]: #cancelled
 
-[7]: #properties-2
+[7]: #match
 
-[8]: #orderaccounts
+[8]: #properties
 
-[9]: #properties-3
+[9]: #order
 
-[10]: #createorderresponse
+[10]: #properties-1
 
-[11]: #properties-4
+[11]: #pendingorders
 
-[12]: #cancelorderresponse
+[12]: #properties-2
 
-[13]: #properties-5
+[13]: #orderaccounts
 
-[14]: #cancelordersresponse
+[14]: #properties-3
 
-[15]: #properties-6
+[15]: #createorderresponse
 
-[16]: #orderpdaresponse
+[16]: #properties-4
 
-[17]: #properties-7
+[17]: #cancelorderresponse
 
-[18]: #stakeinteger
+[18]: #properties-5
 
-[19]: #properties-8
+[19]: #cancelordersresponse
 
-[20]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[20]: #properties-6
 
-[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[21]: #orderpdaresponse
 
-[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[22]: #properties-7
 
-[23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[23]: #stakeinteger
+
+[24]: #properties-8
+
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/npm-client/src/cancel_order.ts
+++ b/npm-client/src/cancel_order.ts
@@ -19,7 +19,7 @@ import { NoCancellableOrdersFound } from "../types";
 /**
  * For the provided order publicKey, cancel the order if the program provider owns the order.Orders can be cancelled if they:
  *
- * - Have the status of OrderStatus.OPEN
+ * - Have the status of OPEN
  * - Are partially matched (only unmatched stake will be cancelled)
  *
  * @param program {program} anchor program initialized by the consuming client
@@ -91,7 +91,7 @@ export async function cancelOrder(
 /**
  * For the provided market publicKey, attempt to cancel all cancellable orders owned by the program provider wallet. Orders can be cancelled if they:
  *
- * - Have the status of OrderStatus.OPEN
+ * - Have the status of OPEN
  * - Are partially matched (only unmatched stake will be cancelled)
  *
  * @param program {program} anchor program initialized by the consuming client

--- a/npm-client/src/market_query.ts
+++ b/npm-client/src/market_query.ts
@@ -6,9 +6,17 @@ import {
   MarketAccounts,
   MarketAccount,
   GetPublicKeys,
-  MarketStatus,
 } from "../types";
 import { PublicKeyCriterion, ByteCriterion, toFilters } from "./queries";
+
+export enum MarketStatusFilter {
+  Initializing = 0x00,
+  Open = 0x01,
+  Locked = 0x02,
+  ReadyForSettlement = 0x03,
+  Settled = 0x04,
+  ReadyToClose = 0x05,
+}
 
 export class Markets {
   /**
@@ -28,7 +36,7 @@ export class Markets {
    * const eventPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
    * const markets = await Markets.marketQuery(program)
    *      .filterByAuthority(authorityPk)
-   *      .filterByStatus(MarketStatus.Settled)
+   *      .filterByStatus(MarketStatusFilter.Settled)
    *      .filterByEvent(eventPk)
    *      .fetch();
    *
@@ -64,7 +72,7 @@ export class Markets {
     return this;
   }
 
-  filterByStatus(status: MarketStatus): Markets {
+  filterByStatus(status: MarketStatusFilter): Markets {
     this.status.setValue(status);
     return this;
   }
@@ -137,16 +145,16 @@ export class Markets {
  * Get all market accounts for the provided market status.
  *
  * @param program {program} anchor program initialized by the consuming client
- * @param status {MarketStatus} status of the market, provided by the MarketStatus enum
+ * @param status {MarketStatusFilter} status of the market, provided by the MarketStatusFilter enum
  * @returns { MarketAccounts } fetched market accounts mapped to their publicKey
  *
  * @example
- * const status = MarketStatus.Open
+ * const status = MarketStatusFilter.Open
  * const marketAccounts = await getMarketAccountsByStatus(program, status)
  */
 export async function getMarketAccountsByStatus(
   program: Program,
-  status: MarketStatus,
+  status: MarketStatusFilter,
 ): Promise<ClientResponse<MarketAccounts>> {
   return await Markets.marketQuery(program).filterByStatus(status).fetch();
 }
@@ -173,18 +181,18 @@ export async function getMarketAccountsByEvent(
  * Get all market accounts for the provided market status and mint account.
  *
  * @param program {program} anchor program initialized by the consuming client
- * @param status {MarketStatus} status of the market, provided by the MarketStatus enum
+ * @param status {MarketStatusFilter} status of the market, provided by the MarketStatusFilter enum
  * @param mintAccount {PublicKey} publicKey of the mint account
  * @returns {MarketAccounts} fetched market accounts mapped to their publicKey
  *
  * @example
- * const status = MarketStatus.Open
+ * const status = MarketStatusFilter.Open
  * const mintAccount = new PublicKey("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU")
  * const marketAccounts = await getMarketAccountsByStatusAndMintAccount(program, status, mintAccount)
  */
 export async function getMarketAccountsByStatusAndMintAccount(
   program: Program,
-  status: MarketStatus,
+  status: MarketStatusFilter,
   mintAccount: PublicKey,
 ): Promise<ClientResponse<MarketAccounts>> {
   return await Markets.marketQuery(program)

--- a/npm-client/src/order.ts
+++ b/npm-client/src/order.ts
@@ -4,12 +4,11 @@ import {
   Order,
   OrderAccounts,
   orderPdaResponse,
-  OrderStatus,
   PendingOrders,
 } from "../types/order";
 import { ClientResponse, ResponseFactory } from "../types/client";
 import { GetAccount } from "../types/get_account";
-import { Orders } from "./order_query";
+import { Orders, OrderStatusFilter } from "./order_query";
 
 /**
  * For the provided market publicKey and wallet publicKey: add a date seed and return a Program Derived Address (PDA) and the seed used. This PDA is used for order creation.
@@ -139,11 +138,11 @@ export async function getPendingOrdersForMarket(
   const [matchedOrdersResponse, openOrdersResponse] = await Promise.all([
     await new Orders(program)
       .filterByMarket(marketPk)
-      .filterByStatus(OrderStatus.Matched)
+      .filterByStatus(OrderStatusFilter.Matched)
       .fetch(),
     await new Orders(program)
       .filterByMarket(marketPk)
-      .filterByStatus(OrderStatus.Open)
+      .filterByStatus(OrderStatusFilter.Open)
       .fetch(),
   ]);
 
@@ -178,12 +177,12 @@ export async function getPendingOrdersForMarketByOutcomeIndex(
     await new Orders(program)
       .filterByMarket(marketPk)
       .filterByMarketOutcomeIndex(outcomeIndex)
-      .filterByStatus(OrderStatus.Matched)
+      .filterByStatus(OrderStatusFilter.Matched)
       .fetch(),
     await new Orders(program)
       .filterByMarket(marketPk)
       .filterByMarketOutcomeIndex(outcomeIndex)
-      .filterByStatus(OrderStatus.Open)
+      .filterByStatus(OrderStatusFilter.Open)
       .fetch(),
   ]);
 
@@ -222,13 +221,13 @@ export async function filterByMarketAndMarketOutcomeIndexAndStatusAndForOutcome(
       .filterByMarket(marketPk)
       .filterByMarketOutcomeIndex(outcomeIndex)
       .filterByForOutcome(forOutcome)
-      .filterByStatus(OrderStatus.Matched)
+      .filterByStatus(OrderStatusFilter.Matched)
       .fetch(),
     await new Orders(program)
       .filterByMarket(marketPk)
       .filterByMarketOutcomeIndex(outcomeIndex)
       .filterByForOutcome(forOutcome)
-      .filterByStatus(OrderStatus.Open)
+      .filterByStatus(OrderStatusFilter.Open)
       .fetch(),
   ]);
 

--- a/npm-client/src/order_query.ts
+++ b/npm-client/src/order_query.ts
@@ -3,7 +3,6 @@ import { Program, AnchorProvider } from "@project-serum/anchor";
 import { GetAccount } from "../types/get_account";
 import {
   Order,
-  OrderStatus,
   ClientResponse,
   ResponseFactory,
   GetPublicKeys,
@@ -16,6 +15,14 @@ import {
   ByteCriterion,
   toFilters,
 } from "./queries";
+
+export enum OrderStatusFilter {
+  Open = 0x00,
+  Matched = 0x01,
+  SettledWin = 0x02,
+  SettledLose = 0x03,
+  Cancelled = 0x04,
+}
 
 /**
  * Base order query builder allowing to filter by set fields. Returns publicKeys or accounts mapped to those publicKeys; filtered to remove any accounts closed during the query process.
@@ -35,7 +42,7 @@ import {
  * const orders = await Orders.orderQuery(program)
  *       .filterByMarket(marketPk)
  *       .filterByPurchaser(purchaserPk)
- *       .filterByStatus(OrderStatus.Open)
+ *       .filterByStatus(OrderStatusFilter.Open)
  *       .fetch();
  *
  * // Returns all open order accounts for the specified market and purchasing wallet.
@@ -77,7 +84,7 @@ export class Orders {
     return this;
   }
 
-  filterByStatus(status: OrderStatus): Orders {
+  filterByStatus(status: OrderStatusFilter): Orders {
     this.status.setValue(status);
     return this;
   }
@@ -160,12 +167,12 @@ export class Orders {
  * @returns {OrderAccounts} fetched order accounts mapped to their publicKey
  *
  * @example
- * const status = OrderStatus.Open
+ * const status = OrderStatusFilter.Open
  * const orders = await getOrdersByStatusForProviderWallet(program, status)
  */
 export async function getOrdersByStatusForProviderWallet(
   program: Program,
-  status: OrderStatus,
+  status: OrderStatusFilter,
 ): Promise<ClientResponse<OrderAccounts>> {
   const provider = program.provider as AnchorProvider;
   return await Orders.orderQuery(program)
@@ -198,7 +205,7 @@ export async function getOrdersByMarketForProviderWallet(
 /**
  * Get all cancellable orders owned by the program provider for the given market. Orders can be cancelled if they:
  *
- * - Have the status of OrderStatus.OPEN
+ * - Have the status of OPEN
  * - Are partially matched (only unmatched stake will be cancelled)
  *
  * @param program {program} anchor program initialized by the consuming client

--- a/npm-client/types/market.ts
+++ b/npm-client/types/market.ts
@@ -3,13 +3,13 @@ import { PublicKey } from "@solana/web3.js";
 import { Order, PendingOrders } from "./order";
 import { GetAccount } from "./get_account";
 
-export enum MarketStatus {
-  Initializing = 0x00,
-  Open = 0x01,
-  Locked = 0x02,
-  ReadyForSettlement = 0x03,
-  Settled = 0x04,
-  ReadyToClose = 0x05,
+export interface MarketStatus {
+  readonly initializing?: Record<string, never>;
+  readonly open?: Record<string, never>;
+  readonly locked?: Record<string, never>;
+  readonly readyForSettlement?: Record<string, never>;
+  readonly settled?: Record<string, never>;
+  readonly readyToClose?: Record<string, never>;
 }
 
 export enum MarketType {

--- a/npm-client/types/order.ts
+++ b/npm-client/types/order.ts
@@ -2,7 +2,7 @@ import { PublicKey } from "@solana/web3.js";
 import { BN } from "@project-serum/anchor";
 import { GetAccount } from "./get_account";
 
-export class OrderStatus {
+export interface OrderStatus {
   readonly open?: Record<string, never>;
   readonly matched?: Record<string, never>;
   readonly settledWin?: Record<string, never>;

--- a/npm-client/types/order.ts
+++ b/npm-client/types/order.ts
@@ -2,12 +2,12 @@ import { PublicKey } from "@solana/web3.js";
 import { BN } from "@project-serum/anchor";
 import { GetAccount } from "./get_account";
 
-export enum OrderStatus {
-  Open = 0x00,
-  Matched = 0x01,
-  SettledWin = 0x02,
-  SettledLose = 0x03,
-  Cancelled = 0x04,
+export class OrderStatus {
+  open?: Record<string, never>;
+  matched?: Record<string, never>;
+  settledWin?: Record<string, never>;
+  settledLose?: Record<string, never>;
+  cancelled?: Record<string, never>;
 }
 
 export type Match = {

--- a/npm-client/types/order.ts
+++ b/npm-client/types/order.ts
@@ -3,11 +3,11 @@ import { BN } from "@project-serum/anchor";
 import { GetAccount } from "./get_account";
 
 export class OrderStatus {
-  open?: Record<string, never>;
-  matched?: Record<string, never>;
-  settledWin?: Record<string, never>;
-  settledLose?: Record<string, never>;
-  cancelled?: Record<string, never>;
+  readonly open?: Record<string, never>;
+  readonly matched?: Record<string, never>;
+  readonly settledWin?: Record<string, never>;
+  readonly settledLose?: Record<string, never>;
+  readonly cancelled?: Record<string, never>;
 }
 
 export type Match = {

--- a/tests/npm-admin-client/market_management.ts
+++ b/tests/npm-admin-client/market_management.ts
@@ -18,7 +18,6 @@ import {
   openMarket,
 } from "../../npm-admin-client/src";
 import { monaco } from "../util/wrappers";
-import { checkEnumValue } from "../../admin/leaderboard/util";
 
 describe("Settle market", () => {
   const provider = AnchorProvider.local();
@@ -197,7 +196,7 @@ describe("Market ready to close", () => {
     assert(response.success);
     assert(response.data.tnxId);
     assert.deepEqual(response.errors, []);
-    checkEnumValue(updatedMarket.marketStatus, "readyToClose");
+    assert.deepEqual(updatedMarket.marketStatus, { readyToClose: {} });
   });
 
   it("Fails if market not settled", async () => {
@@ -209,6 +208,6 @@ describe("Market ready to close", () => {
     assert.equal(response.success, false);
     assert.equal(response.data, undefined);
     assert(response.errors);
-    checkEnumValue(updatedMarket.marketStatus, "open");
+    assert.deepEqual(updatedMarket.marketStatus, { open: {} });
   });
 });

--- a/tests/npm-client/market_query.ts
+++ b/tests/npm-client/market_query.ts
@@ -3,7 +3,7 @@ import {
   getMarketAccountsByEvent,
   getMarketAccountsByStatus,
   getMarketAccountsByStatusAndMintAccount,
-  MarketStatus,
+  MarketStatusFilter,
 } from "../../npm-client/src/";
 import { monaco } from "../util/wrappers";
 
@@ -13,7 +13,7 @@ describe("Market Query", () => {
 
     const responseOpen = await getMarketAccountsByStatus(
       monaco.getRawProgram(),
-      MarketStatus.Open,
+      MarketStatusFilter.Open,
     );
 
     assert(responseOpen.success);
@@ -68,7 +68,7 @@ describe("Market Query", () => {
     {
       const response = await getMarketAccountsByStatusAndMintAccount(
         monaco.getRawProgram(),
-        MarketStatus.Open,
+        MarketStatusFilter.Open,
         market1.mintPk,
       );
 
@@ -84,7 +84,7 @@ describe("Market Query", () => {
     {
       const response = await getMarketAccountsByStatusAndMintAccount(
         monaco.getRawProgram(),
-        MarketStatus.Open,
+        MarketStatusFilter.Open,
         market2.mintPk,
       );
 

--- a/tests/npm-client/my_orders.ts
+++ b/tests/npm-client/my_orders.ts
@@ -2,8 +2,7 @@ import { PublicKey } from "@solana/web3.js";
 import { Program } from "@project-serum/anchor";
 import assert from "assert";
 
-import { Orders } from "../../npm-client/src/order_query";
-import { OrderStatus } from "../../npm-client/types/order";
+import { Orders, OrderStatusFilter } from "../../npm-client/src/order_query";
 import { createWalletWithBalance } from "../util/test_util";
 import { monaco } from "../util/wrappers";
 
@@ -144,23 +143,23 @@ describe("Order", () => {
         .fetch(),
       new Orders(monaco.program as Program)
         .filterByPurchaser(wallet1.publicKey)
-        .filterByStatus(OrderStatus.Open)
+        .filterByStatus(OrderStatusFilter.Open)
         .fetch(),
       new Orders(monaco.program as Program)
         .filterByPurchaser(wallet1.publicKey)
-        .filterByStatus(OrderStatus.Matched)
+        .filterByStatus(OrderStatusFilter.Matched)
         .fetch(),
       new Orders(monaco.program as Program)
         .filterByPurchaser(wallet1.publicKey)
         .filterByMarket(market1.pk)
-        .filterByStatus(OrderStatus.Matched)
+        .filterByStatus(OrderStatusFilter.Matched)
         .fetch(),
       new Orders(monaco.program as Program)
-        .filterByStatus(OrderStatus.SettledWin)
+        .filterByStatus(OrderStatusFilter.SettledWin)
         .filterByMarket(market1.pk)
         .fetch(),
       new Orders(monaco.program as Program)
-        .filterByStatus(OrderStatus.SettledWin)
+        .filterByStatus(OrderStatusFilter.SettledWin)
         .filterByMarket(market2.pk)
         .fetch(),
     ]);

--- a/tests/npm-client/order_query.ts
+++ b/tests/npm-client/order_query.ts
@@ -5,7 +5,7 @@ import {
   getOrdersByStatusForProviderWallet,
   getOrdersByEventForProviderWallet,
   getCancellableOrdersByMarketForProviderWallet,
-  OrderStatus,
+  OrderStatusFilter,
   Orders,
 } from "../../npm-client/src";
 import { createOrderUiStake as createOrderNpm } from "../../npm-client/src/create_order";
@@ -57,7 +57,7 @@ describe("Order Query", () => {
 
     const responseByStatus = await getOrdersByStatusForProviderWallet(
       monaco.getRawProgram(),
-      OrderStatus.Open,
+      OrderStatusFilter.Open,
     );
 
     assert(responseByStatus.success);


### PR DESCRIPTION
* fixing enum type returned by anchor when fetching accounts (it's an object rather than just raw int as stored on chain)