### PR TITLE
fix: Accurately convert floating point stake to integer (BN)

### DIFF
--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
+      "dependencies": {
+        "big.js": "^6.2.1"
+      },
       "devDependencies": {
         "@types/bs58": "^4.0.1",
         "documentation": "^14.0.0"
@@ -900,6 +903,18 @@
         }
       ],
       "peer": true
+    },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
@@ -5154,6 +5169,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "peer": true
+    },
+    "big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
     },
     "bigint-buffer": {
       "version": "1.1.5",

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",
@@ -29,11 +29,14 @@
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.3.5",
     "@solana/web3.js": "^1.31.0",
-    "typescript": "^4.5.4",
-    "bs58": "^4.0.1"
+    "bs58": "^4.0.1",
+    "typescript": "^4.5.4"
   },
   "devDependencies": {
     "@types/bs58": "^4.0.1",
     "documentation": "^14.0.0"
+  },
+  "dependencies": {
+    "big.js": "^6.2.1"
   }
 }

--- a/npm-client/src/utils.ts
+++ b/npm-client/src/utils.ts
@@ -1,6 +1,7 @@
 import { PublicKey } from "@solana/web3.js";
 import { AnchorProvider, BN, Program } from "@project-serum/anchor";
 import { Mint, getMint } from "@solana/spl-token";
+import { Big } from "big.js";
 import { getMarket } from "./markets";
 import { findMarketPositionPda } from "./market_position";
 import { findMarketMatchingPoolPda } from "./market_matching_pools";
@@ -109,7 +110,9 @@ export async function uiStakeToInteger(
     return response.body;
   }
 
-  const stakeInteger = new BN(stake * 10 ** mintInfo.data.decimals);
+  const stakeInteger = new BN(
+    new Big(stake).times(10 ** mintInfo.data.decimals).toNumber(),
+  );
   response.addResponseData({
     stakeInteger: stakeInteger,
   });

--- a/tests/npm-client/stake.ts
+++ b/tests/npm-client/stake.ts
@@ -1,0 +1,20 @@
+import { monaco } from "../util/wrappers";
+import { uiStakeToInteger } from "../../npm-client";
+import { Program } from "@project-serum/anchor";
+import assert from "assert";
+
+describe("Stake calculations", () => {
+  it("JS floating point inaccuracies in stake conversion are not observed", async () => {
+    const market = await monaco.create3WayMarket([1.001]);
+
+    const uiStake = 2.01;
+    const expectedResult = 2010000;
+
+    const result = await uiStakeToInteger(
+      monaco.program as Program,
+      uiStake,
+      market.pk,
+    );
+    assert.equal(result.data.stakeInteger.toNumber(), expectedResult);
+  });
+});


### PR DESCRIPTION
TS client fix. 

```
  ● Stake calculations › JS floating point inaccuracies in stake conversion are not observed

    assert.equal(received, expected)

    Expected value to be equal to:
      2010000
    Received:
      2009999
```

Uses big.js to safely transform e.g., 2.01 to 2010000. 

This will be released in client version 3.0.1