### PR TITLE
fix: unblock settlement where market escrow has been transferred to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.6.0"
+version = "0.7.0-rc1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "2.0.1",
+  "version": "3.0.0-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "2.0.1",
+      "version": "3.0.0-rc1",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "2.0.1",
+  "version": "3.0.0-rc1",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-admin-client/src/market_management.ts
+++ b/npm-admin-client/src/market_management.ts
@@ -8,6 +8,7 @@ import {
   EpochTimeStamp,
 } from "../types";
 import { findAuthorisedOperatorsAccountPda } from "./operators";
+import { findEscrowPda } from "./npm-client-duplicates";
 
 /**
  * Settle a market by setting the winningOutcomeIndex
@@ -390,11 +391,18 @@ export async function setMarketReadyToClose(
     return response.body;
   }
 
+  const marketEscrow = await findEscrowPda(program, marketPk);
+  if (!marketEscrow.success) {
+    response.addErrors(marketEscrow.errors);
+    return response.body;
+  }
+
   try {
     const tnxId = await program.methods
       .setMarketReadyToClose()
       .accounts({
         market: marketPk,
+        marketEscrow: marketEscrow.data.pda,
         authorisedOperators: authorisedOperators.data.pda,
         marketOperator: provider.wallet.publicKey,
       })

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.6.0"
+version = "0.7.0-rc1"
 description = "Created with Anchor"
 edition = "2018"
 

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -421,9 +421,39 @@ pub struct UpdateMarket<'info> {
 }
 
 #[derive(Accounts)]
+pub struct SetMarketReadyToClose<'info> {
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+    #[account(
+        token::mint = market.mint_account,
+        token::authority = market_escrow,
+        seeds = [b"escrow".as_ref(), market.key().as_ref()],
+        bump,
+    )]
+    pub market_escrow: Account<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub market_operator: Signer<'info>,
+    #[account(seeds = [b"authorised_operators".as_ref(), b"MARKET".as_ref()], bump)]
+    pub authorised_operators: Account<'info, AuthorisedOperators>,
+}
+
+#[derive(Accounts)]
 pub struct CompleteMarketSettlement<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
+
+    #[account(mut)]
+    pub crank_operator: Signer<'info>,
+    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
+    pub authorised_operators: Account<'info, AuthorisedOperators>,
+}
+
+#[derive(Accounts)]
+pub struct TransferMarketEscrowSurplus<'info> {
+    #[account()]
+    pub market: Account<'info, Market>,
+
     #[account(
         mut,
         token::mint = market.mint_account,
@@ -431,12 +461,22 @@ pub struct CompleteMarketSettlement<'info> {
         seeds = [b"escrow".as_ref(), market.key().as_ref()],
         bump,
     )]
-    pub market_escrow: Box<Account<'info, TokenAccount>>,
+    pub market_escrow: Account<'info, TokenAccount>,
 
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
+    #[account(
+        mut,
+        associated_token::mint = market.mint_account,
+        associated_token::authority = market.authority,
+    )]
+    pub market_authority_token: Account<'info, TokenAccount>,
+
+    pub market_operator: Signer<'info>,
+
+    #[account(seeds = [b"authorised_operators".as_ref(), b"MARKET".as_ref()], bump)]
     pub authorised_operators: Account<'info, AuthorisedOperators>,
+
+    #[account(address = anchor_spl::token::ID)]
+    pub token_program: Program<'info, Token>,
 }
 
 #[derive(Accounts)]

--- a/programs/monaco_protocol/src/instructions/market/escrow.rs
+++ b/programs/monaco_protocol/src/instructions/market/escrow.rs
@@ -1,9 +1,29 @@
 use anchor_lang::prelude::*;
 
 use crate::context::CloseMarket;
+use crate::instructions::transfer;
+use crate::state::market_account::{Market, MarketStatus};
+use crate::CoreError;
 use anchor_lang::context::{Context, CpiContext};
 use anchor_lang::{Key, ToAccountInfo};
 use anchor_spl::token;
+use anchor_spl::token::{Token, TokenAccount};
+
+const TRANSFER_SURPLUS_ALLOWED_STATUSES: [MarketStatus; 2] =
+    [MarketStatus::Settled, MarketStatus::ReadyToClose];
+
+pub fn transfer_market_escrow_surplus<'info>(
+    market: &Account<'info, Market>,
+    market_escrow: &Account<'info, TokenAccount>,
+    destination: &Account<'info, TokenAccount>,
+    token_program: &Program<'info, Token>,
+) -> Result<()> {
+    require!(
+        TRANSFER_SURPLUS_ALLOWED_STATUSES.contains(&market.market_status),
+        CoreError::MarketInvalidStatus
+    );
+    transfer::transfer_market_escrow_surplus(market_escrow, destination, token_program, market)
+}
 
 pub fn close_escrow_token_account(ctx: &Context<CloseMarket>) -> Result<()> {
     token::close_account(CpiContext::new_with_signer(

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -1,6 +1,7 @@
 use crate::context::UpdateMarket;
 use crate::CompleteMarketSettlement;
 use anchor_lang::prelude::*;
+use anchor_spl::token::TokenAccount;
 use solana_program::clock::UnixTimestamp;
 
 use crate::error::CoreError;
@@ -37,11 +38,6 @@ pub fn settle(
 }
 
 pub fn complete_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
-    require!(
-        ctx.accounts.market_escrow.amount == 0_u64,
-        CoreError::SettlementMarketEscrowNonZero
-    );
-
     let market = &mut ctx.accounts.market;
     require!(
         ReadyForSettlement.eq(&market.market_status),
@@ -75,11 +71,16 @@ pub fn unsuspend(ctx: Context<UpdateMarket>) -> Result<()> {
     Ok(())
 }
 
-pub fn ready_to_close(market: &mut Market) -> Result<()> {
+pub fn ready_to_close(market: &mut Market, market_escrow: &TokenAccount) -> Result<()> {
     require!(
         Settled.eq(&market.market_status),
         CoreError::MarketNotSettled
     );
+    require!(
+        market_escrow.amount == 0_u64,
+        CoreError::SettlementMarketEscrowNonZero
+    );
+
     market.market_status = ReadyToClose;
     Ok(())
 }
@@ -87,7 +88,7 @@ pub fn ready_to_close(market: &mut Market) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::error::CoreError;
-    use crate::instructions::market::{open, ready_to_close, settle};
+    use crate::instructions::market::{open, settle};
     use crate::state::market_account::MarketStatus;
     use crate::Market;
     use anchor_lang::error;
@@ -224,56 +225,6 @@ mod tests {
 
         assert!(result.is_err());
         let expected_error = Err(error!(CoreError::OpenMarketNotInitializing));
-        assert_eq!(expected_error, result)
-    }
-
-    #[test]
-    fn ready_to_close_market() {
-        let mut market = Market {
-            authority: Default::default(),
-            event_account: Default::default(),
-            mint_account: Default::default(),
-            market_status: MarketStatus::Settled,
-            market_type: "".to_string(),
-            decimal_limit: 0,
-            published: false,
-            suspended: false,
-            market_outcomes_count: 0,
-            market_winning_outcome_index: None,
-            market_lock_timestamp: 0,
-            market_settle_timestamp: None,
-            title: "".to_string(),
-            escrow_account_bump: 0,
-        };
-
-        let result = ready_to_close(&mut market);
-        assert!(result.is_ok());
-        assert_eq!(market.market_status, MarketStatus::ReadyToClose)
-    }
-
-    #[test]
-    fn ready_to_close_market_market_not_settled() {
-        let mut market = Market {
-            authority: Default::default(),
-            event_account: Default::default(),
-            mint_account: Default::default(),
-            market_status: MarketStatus::ReadyForSettlement,
-            market_type: "".to_string(),
-            decimal_limit: 0,
-            published: false,
-            suspended: false,
-            market_outcomes_count: 0,
-            market_winning_outcome_index: None,
-            market_lock_timestamp: 0,
-            market_settle_timestamp: None,
-            title: "".to_string(),
-            escrow_account_bump: 0,
-        };
-
-        let result = ready_to_close(&mut market);
-
-        assert!(result.is_err());
-        let expected_error = Err(error!(CoreError::MarketNotSettled));
         assert_eq!(expected_error, result)
     }
 }

--- a/programs/monaco_protocol/src/instructions/transfer.rs
+++ b/programs/monaco_protocol/src/instructions/transfer.rs
@@ -89,6 +89,23 @@ pub fn transfer_settlement_funds(ctx: &Context<SettleOrder>, amount: u64) -> Res
     )
 }
 
+pub fn transfer_market_escrow_surplus<'info>(
+    market_escrow: &Account<'info, TokenAccount>,
+    purchaser_token_account: &Account<'info, TokenAccount>,
+    token_program: &Program<'info, Token>,
+    market: &Account<Market>,
+) -> Result<()> {
+    let amount: u64 = market_escrow.amount;
+    msg!("Transferring surplus of {} from escrow", amount);
+    transfer_from_market_escrow(
+        market_escrow,
+        purchaser_token_account,
+        token_program,
+        market,
+        amount,
+    )
+}
+
 fn transfer_to_market_escrow<'info>(
     market_escrow: &Account<'info, TokenAccount>,
     purchaser: &Signer<'info>,

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -323,7 +323,7 @@ pub mod monaco_protocol {
         instructions::market::unsuspend(ctx)
     }
 
-    pub fn set_market_ready_to_close(ctx: Context<UpdateMarket>) -> Result<()> {
+    pub fn set_market_ready_to_close(ctx: Context<SetMarketReadyToClose>) -> Result<()> {
         verify_operator_authority(
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
@@ -333,7 +333,25 @@ pub mod monaco_protocol {
             &ctx.accounts.market.authority,
         )?;
 
-        instructions::market::ready_to_close(&mut ctx.accounts.market)
+        instructions::market::ready_to_close(&mut ctx.accounts.market, &ctx.accounts.market_escrow)
+    }
+
+    pub fn transfer_market_escrow_surplus(ctx: Context<TransferMarketEscrowSurplus>) -> Result<()> {
+        verify_operator_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.authorised_operators,
+        )?;
+        verify_market_authority(
+            ctx.accounts.market_operator.key,
+            &ctx.accounts.market.authority,
+        )?;
+
+        instructions::market::transfer_market_escrow_surplus(
+            &ctx.accounts.market,
+            &ctx.accounts.market_escrow,
+            &ctx.accounts.market_authority_token,
+            &ctx.accounts.token_program,
+        )
     }
 
     pub fn create_product_config(

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -50,6 +50,7 @@ export class Monaco {
   readonly provider: anchor.AnchorProvider;
   readonly program: Program<MonacoProtocol>;
   readonly operatorPk: PublicKey;
+  readonly operatorWallet: NodeWallet;
 
   private marketAuthorisedOperatorsPk: PublicKey;
   private crankAuthorisedOperatorsPk: PublicKey;
@@ -61,6 +62,7 @@ export class Monaco {
     this.provider = provider;
     this.program = program;
     this.operatorPk = provider.wallet.publicKey;
+    this.operatorWallet = provider.wallet as NodeWallet;
   }
 
   getRawProgram(): Program {
@@ -857,7 +859,6 @@ export class MonacoMarket {
       .completeMarketSettlement()
       .accounts({
         market: this.pk,
-        marketEscrow: this.escrowPk,
         crankOperator: this.monaco.operatorPk,
         authorisedOperators:
           await this.monaco.findCrankAuthorisedOperatorsPda(),
@@ -874,6 +875,7 @@ export class MonacoMarket {
       .setMarketReadyToClose()
       .accounts({
         market: this.pk,
+        marketEscrow: this.escrowPk,
         marketOperator: this.marketAuthority
           ? this.marketAuthority.publicKey
           : this.monaco.operatorPk,


### PR DESCRIPTION
Successful market settlement expects program transfers in and out of escrow to balance, resulting in an account balance of 0 tokens. There is an explicit check to ensure settlement only fully completes when escrow's balance equals 0. 

If someone manually transfers tokens to escrow then this check will prevent settlement from completing.

An alternative method of tracking the program transfers to/from escrow will be required to continue to allow this check at settlement time. 

For now, this PR will move the balance check from settlement complete to the instruction for moving a market status from Settled to ReadyToClose. In addition a new instruction has been added to allow a market authority to transfer any surplus balance, post settlement completing successfully, from escrow, enabling all markets accounts to be closed. 

These changes allow the market lifecycle to complete, as well as ensures all settlement payouts are completed before the market authority can attempt to withdraw from market escrow. 

tl;dr
* Move balance check to set_ready_to_close
* Add ix to transfer surplus