### PR TITLE
chore: bump version to 0.9.0-rc3 with audit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.9.0-rc2"
+version = "0.9.0-rc3"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "4.1.0-rc1",
+  "version": "4.1.0-rc3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "4.1.0-rc1",
+      "version": "4.1.0-rc3",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "4.1.0-rc1",
+  "version": "4.1.0-rc3",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "6.0.0-rc1",
+  "version": "6.0.0-rc3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "6.0.0-rc1",
+      "version": "6.0.0-rc3",
       "license": "MIT",
       "dependencies": {
         "big.js": "^6.2.1"

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "6.0.0-rc1",
+  "version": "6.0.0-rc3",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.9.0-rc2"
+version = "0.9.0-rc3"
 description = "Created with Anchor"
 edition = "2018"
 


### PR DESCRIPTION
Bump versions to RC3 so we can publish new packages.