### PR TITLE
fix(client): add missing payer field to MarketPosition account type

### DIFF
--- a/npm-client/docs/types/market_position.md
+++ b/npm-client/docs/types/market_position.md
@@ -9,7 +9,7 @@
 
 ## MarketPosition
 
-Type: {purchaser: PublicKey, market: PublicKey, paid: [boolean][5], marketOutcomeSums: [Array][6]\<BN>, outcomeMaxExposure: [Array][6]\<BN>, outcomePositions: [Map][7]<[string][8], BN>}
+Type: {purchaser: PublicKey, market: PublicKey, paid: [boolean][5], marketOutcomeSums: [Array][6]\<BN>, outcomeMaxExposure: [Array][6]\<BN>, outcomePositions: [Map][7]<[string][8], BN>, payer: PublicKey}
 
 ### Properties
 
@@ -19,6 +19,7 @@ Type: {purchaser: PublicKey, market: PublicKey, paid: [boolean][5], marketOutcom
 *   `marketOutcomeSums` **[Array][6]\<BN>**&#x20;
 *   `outcomeMaxExposure` **[Array][6]\<BN>**&#x20;
 *   `outcomePositions` **[Map][7]<[string][8], BN>**&#x20;
+*   `payer` **PublicKey**&#x20;
 
 ## MarketPositionAccounts
 

--- a/npm-client/types/market_position.ts
+++ b/npm-client/types/market_position.ts
@@ -9,6 +9,7 @@ export type MarketPosition = {
   marketOutcomeSums: BN[];
   outcomeMaxExposure: BN[];
   outcomePositions: Map<string, BN>;
+  payer: PublicKey;
 };
 
 export type MarketPositionAccounts = {


### PR DESCRIPTION
A small miss from the client changes for the 0.9.0 release