### PR TITLE
fix: don't subtract an order's liquidity from MarketMatchingPool available liquidity on cancel if its not yet been added to the total

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const jestConfig = {
     verbose: true,
-    testMatch: ["**/tests/protocol/cancel_order.ts?(x)"],
+    testMatch: ["**/tests/**/*.ts?(x)"],
     testPathIgnorePatterns: [
         "tests/setup.ts",
         "tests/util/pdas.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const jestConfig = {
     verbose: true,
-    testMatch: ["**/tests/**/*.ts?(x)"],
+    testMatch: ["**/tests/protocol/cancel_order.ts?(x)"],
     testPathIgnorePatterns: [
         "tests/setup.ts",
         "tests/util/pdas.ts",

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -219,12 +219,14 @@ pub fn update_on_cancel(
     order: &Account<Order>,
     matching_pool: &mut MarketMatchingPool,
 ) -> Result<()> {
-    // TODO update market_outcome stake sums for partially matched orders
-    matching_pool.liquidity_amount = matching_pool
-        .liquidity_amount
-        .checked_sub(order.voided_stake)
-        .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
-    matching_pool.orders.remove_pubkey(&order.key());
-
+    if let Some(removed_item) = matching_pool.orders.remove_pubkey(&order.key()) {
+        if removed_item.liquidity_to_add == 0 {
+            // TODO update market_outcome stake sums for partially matched orders
+            matching_pool.liquidity_amount = matching_pool
+                .liquidity_amount
+                .checked_sub(order.voided_stake)
+                .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
+        }
+    }
     Ok(())
 }

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -136,7 +136,65 @@ describe("Security: Cancel Order", () => {
 
     const orderPk = await market.forOrder(0, stake, price, purchaser);
 
+    let matchingPool = await market.getForMatchingPool(0, price);
+    assert.equal(matchingPool.liquidity, 0);
+
+    // This should succeed and no error should be thrown
     await market.cancel(orderPk, purchaser);
+
+    // check liquidity is unchanged
+    matchingPool = await market.getForMatchingPool(0, price);
+    assert.equal(matchingPool.liquidity, 0);
+
+    // check order was deleted
+    try {
+      await monaco.program.account.order.fetch(orderPk);
+      assert.fail("Account should not exist");
+    } catch (e) {
+      assert.equal(
+        e.message,
+        "Account does not exist or has no data " + orderPk,
+      );
+    }
+  });
+
+  it("liquidity doesn't change if inplay order cancelled after inplay delay but before liquidity is added", async () => {
+    const inplayDelay = 0;
+
+    const now = Math.floor(new Date().getTime() / 1000);
+    const eventStartTimestamp = now - 1000;
+    const marketLockTimestamp = now + 1000;
+
+    // Set up Market and related accounts
+    const [purchaser, market] = await Promise.all([
+      createWalletWithBalance(monaco.provider),
+      monaco.create3WayMarket(
+        [price],
+        true,
+        inplayDelay,
+        eventStartTimestamp,
+        marketLockTimestamp,
+      ),
+    ]);
+    await market.airdrop(purchaser, 10_000);
+
+    await market.forOrder(0, stake, price, purchaser);
+    await market.processDelayExpiredOrders(0, price, true);
+
+    let matchingPool = await market.getForMatchingPool(0, price);
+    assert.equal(matchingPool.liquidity, 0);
+
+    const orderPk = await market.forOrder(0, stake, price, purchaser);
+
+    // check liquidity is unchanged
+    matchingPool = await market.getForMatchingPool(0, price);
+    assert.equal(matchingPool.liquidity, stake);
+
+    await market.cancel(orderPk, purchaser);
+
+    // check liquidity is unchanged
+    matchingPool = await market.getForMatchingPool(0, price);
+    assert.equal(matchingPool.liquidity, stake);
 
     // check order was deleted
     try {

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -182,7 +182,7 @@ describe("Security: Cancel Order", () => {
     await market.processDelayExpiredOrders(0, price, true);
 
     let matchingPool = await market.getForMatchingPool(0, price);
-    assert.equal(matchingPool.liquidity, 0);
+    assert.equal(matchingPool.liquidity, stake);
 
     const orderPk = await market.forOrder(0, stake, price, purchaser);
 


### PR DESCRIPTION
There is an issue whereby cancelling an order in an inplay market could result in incorrectly affecting the total available liquidity in a matching pool.  

A delayed order's liquidity isn't added to the total liquidity for a matching pool until the delay for the order has expired (is in the past) and either:
* `process_delay_expired_orders` is called for the matching pool containing the order, or
* `match_orders` is called for the order or some other delay expired order at the front of the same matching queue

The issue arises when the order is cancelled between the order's delay expiring and its liquidity being added to the total available liquidity. There is an attempt to subtract the order's liquidity from the total but it has not been added to the total yet. The result being, either the cancellation attempt will fail (best case), or the total available liquidity will be lower than it should be from that point onwards, and potentially some other cancellation attempt or matching attempt in the future for the same matching pool will fail for no reason of the orders involved. 

The fix is straight forward and is to make the `update_on_cancel` function - used to update a `MarketMatchingPool` when cancelling an order - aware of the context of the order being cancelled / removed from the queue. Only subtracting the order's soon-to-be-voided liquidity from the total if that liquidity has already been added to the total, i.e., `queue_item.liquidity_to_add == 0`. 