### PR TITLE
feat: admin-client - add endpoints to update event start time on a market account

### DIFF
--- a/npm-admin-client/docs/endpoints/market_management.md
+++ b/npm-admin-client/docs/endpoints/market_management.md
@@ -20,21 +20,27 @@
 *   [updateMarketTitle][16]
     *   [Parameters][17]
     *   [Examples][18]
-*   [updateMarketLocktime][19]
+*   [updateMarketEventStarttime][19]
     *   [Parameters][20]
     *   [Examples][21]
-*   [openMarket][22]
+*   [setMarketEventStartToNow][22]
     *   [Parameters][23]
     *   [Examples][24]
-*   [setMarketReadyToClose][25]
+*   [updateMarketLocktime][25]
     *   [Parameters][26]
     *   [Examples][27]
-*   [voidMarket][28]
+*   [openMarket][28]
     *   [Parameters][29]
     *   [Examples][30]
-*   [transferMarketEscrowSurplus][31]
+*   [setMarketReadyToClose][31]
     *   [Parameters][32]
     *   [Examples][33]
+*   [voidMarket][34]
+    *   [Parameters][35]
+    *   [Examples][36]
+*   [transferMarketEscrowSurplus][37]
+    *   [Parameters][38]
+    *   [Examples][39]
 
 ## settleMarket
 
@@ -44,7 +50,7 @@ Settle a market by setting the winningOutcomeIndex
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
 *   `marketPk` **PublicKey** {PublicKey} publicKey of the market to settle
-*   `winningOutcomeIndex` **[number][34]** {number} index representing the winning outcome of the event associated with the market
+*   `winningOutcomeIndex` **[number][40]** {number} index representing the winning outcome of the event associated with the market
 
 ### Examples
 
@@ -136,7 +142,7 @@ For the given market, update the title
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
 *   `marketPk` **PublicKey** {PublicKey} publicKey of the market to update
-*   `title` **[string][35]** {string} new title to apply to the provided market
+*   `title` **[string][41]** {string} new title to apply to the provided market
 
 ### Examples
 
@@ -144,6 +150,44 @@ For the given market, update the title
 const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
 const newTitle = "New Market Title"
 const update = await updateMarketTitle(program, marketPk, newTitle)
+```
+
+Returns **TransactionResponse** transaction ID of the request
+
+## updateMarketEventStarttime
+
+For the given market, update the event start time
+
+### Parameters
+
+*   `program` **Program** {program} anchor program initialized by the consuming client
+*   `marketPk` **PublicKey** {PublicKey} publicKey of the market to update
+*   `eventStartTimeTimestamp` **EpochTimeStamp** {EpochTimeStamp} timestamp in seconds representing the new time when the market event will start (moving in-play markets to in-play)
+
+### Examples
+
+```javascript
+const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+const eventStart = 1633042800
+const update = await updateMarketEventStarttime(program, marketPk, eventStart)
+```
+
+Returns **TransactionResponse** transaction ID of the request
+
+## setMarketEventStartToNow
+
+For the given market, update the event start time to now
+
+### Parameters
+
+*   `program` **Program** {program} anchor program initialized by the consuming client
+*   `marketPk` **PublicKey** {PublicKey} publicKey of the market to update
+
+### Examples
+
+```javascript
+const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+const update = await setMarketEventStartToNow(program, marketPk)
 ```
 
 Returns **TransactionResponse** transaction ID of the request
@@ -284,36 +328,48 @@ Returns **TransactionResponse** transaction ID of the request
 
 [18]: #examples-5
 
-[19]: #updatemarketlocktime
+[19]: #updatemarketeventstarttime
 
 [20]: #parameters-6
 
 [21]: #examples-6
 
-[22]: #openmarket
+[22]: #setmarketeventstarttonow
 
 [23]: #parameters-7
 
 [24]: #examples-7
 
-[25]: #setmarketreadytoclose
+[25]: #updatemarketlocktime
 
 [26]: #parameters-8
 
 [27]: #examples-8
 
-[28]: #voidmarket
+[28]: #openmarket
 
 [29]: #parameters-9
 
 [30]: #examples-9
 
-[31]: #transfermarketescrowsurplus
+[31]: #setmarketreadytoclose
 
 [32]: #parameters-10
 
 [33]: #examples-10
 
-[34]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[34]: #voidmarket
 
-[35]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[35]: #parameters-11
+
+[36]: #examples-11
+
+[37]: #transfermarketescrowsurplus
+
+[38]: #parameters-12
+
+[39]: #examples-12
+
+[40]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[41]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/npm-admin-client/docs/endpoints/market_management.md
+++ b/npm-admin-client/docs/endpoints/market_management.md
@@ -20,7 +20,7 @@
 *   [updateMarketTitle][16]
     *   [Parameters][17]
     *   [Examples][18]
-*   [updateMarketEventStarttime][19]
+*   [updateMarketEventStartTime][19]
     *   [Parameters][20]
     *   [Examples][21]
 *   [setMarketEventStartToNow][22]
@@ -154,7 +154,7 @@ const update = await updateMarketTitle(program, marketPk, newTitle)
 
 Returns **TransactionResponse** transaction ID of the request
 
-## updateMarketEventStarttime
+## updateMarketEventStartTime
 
 For the given market, update the event start time
 
@@ -169,7 +169,7 @@ For the given market, update the event start time
 ```javascript
 const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
 const eventStart = 1633042800
-const update = await updateMarketEventStarttime(program, marketPk, eventStart)
+const update = await updateMarketEventStartTime(program, marketPk, eventStart)
 ```
 
 Returns **TransactionResponse** transaction ID of the request

--- a/npm-admin-client/src/market_management.ts
+++ b/npm-admin-client/src/market_management.ts
@@ -290,9 +290,9 @@ export async function updateMarketTitle(
  * @example
  * const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
  * const eventStart = 1633042800
- * const update = await updateMarketEventStarttime(program, marketPk, eventStart)
+ * const update = await updateMarketEventStartTime(program, marketPk, eventStart)
  */
-export async function updateMarketEventStarttime(
+export async function updateMarketEventStartTime(
   program: Program,
   marketPk: PublicKey,
   eventStartTimeTimestamp: EpochTimeStamp,

--- a/npm-admin-client/src/market_management.ts
+++ b/npm-admin-client/src/market_management.ts
@@ -280,6 +280,97 @@ export async function updateMarketTitle(
 }
 
 /**
+ * For the given market, update the event start time
+ *
+ * @param program {program} anchor program initialized by the consuming client
+ * @param marketPk {PublicKey} publicKey of the market to update
+ * @param eventStartTimeTimestamp {EpochTimeStamp} timestamp in seconds representing the new time when the market event will start (moving in-play markets to in-play)
+ * @returns {TransactionResponse} transaction ID of the request
+ *
+ * @example
+ * const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+ * const eventStart = 1633042800
+ * const update = await updateMarketEventStarttime(program, marketPk, eventStart)
+ */
+export async function updateMarketEventStarttime(
+  program: Program,
+  marketPk: PublicKey,
+  eventStartTimeTimestamp: EpochTimeStamp,
+): Promise<ClientResponse<TransactionResponse>> {
+  const { response, provider, authorisedOperators } =
+    await setupManagementRequest(program);
+
+  if (!authorisedOperators.success) {
+    response.addErrors(authorisedOperators.errors);
+    return response.body;
+  }
+
+  try {
+    const tnxId = await program.methods
+      .updateMarketEventStartTime(new BN(eventStartTimeTimestamp))
+      .accounts({
+        market: marketPk,
+        authorisedOperators: authorisedOperators.data.pda,
+        marketOperator: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    response.addResponseData({
+      tnxId: tnxId,
+    });
+  } catch (e) {
+    response.addError(e);
+    return response.body;
+  }
+
+  return response.body;
+}
+
+/**
+ * For the given market, update the event start time to now
+ *
+ * @param program {program} anchor program initialized by the consuming client
+ * @param marketPk {PublicKey} publicKey of the market to update
+ * @returns {TransactionResponse} transaction ID of the request
+ *
+ * @example
+ * const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+ * const update = await setMarketEventStartToNow(program, marketPk)
+ */
+export async function setMarketEventStartToNow(
+  program: Program,
+  marketPk: PublicKey,
+): Promise<ClientResponse<TransactionResponse>> {
+  const { response, provider, authorisedOperators } =
+    await setupManagementRequest(program);
+
+  if (!authorisedOperators.success) {
+    response.addErrors(authorisedOperators.errors);
+    return response.body;
+  }
+
+  try {
+    const tnxId = await program.methods
+      .updateMarketEventStartTimeToNow()
+      .accounts({
+        market: marketPk,
+        authorisedOperators: authorisedOperators.data.pda,
+        marketOperator: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    response.addResponseData({
+      tnxId: tnxId,
+    });
+  } catch (e) {
+    response.addError(e);
+    return response.body;
+  }
+
+  return response.body;
+}
+
+/**
  * For the given market, update the lock time
  *
  * @param program {program} anchor program initialized by the consuming client
@@ -530,7 +621,7 @@ export async function transferMarketEscrowSurplus(
       .rpc();
     response.addResponseData({ tnxId });
   } catch (e) {
-    response.addErrors(e);
+    response.addError(e);
     return response.body;
   }
   return response.body;

--- a/tests/npm-admin-client/market_management.ts
+++ b/tests/npm-admin-client/market_management.ts
@@ -18,7 +18,7 @@ import {
   voidMarket,
   openMarket,
   transferMarketEscrowSurplus,
-  updateMarketEventStarttime,
+  updateMarketEventStartTime,
   setMarketEventStartToNow,
 } from "../../npm-admin-client/src";
 import { monaco } from "../util/wrappers";
@@ -163,7 +163,7 @@ describe("Set new event start", () => {
   it("Sets provided event start time", async () => {
     const protocolProgram = workspace.MonacoProtocol as Program;
     const market = await monaco.create3WayMarket([1.001]);
-    const response = await updateMarketEventStarttime(
+    const response = await updateMarketEventStartTime(
       protocolProgram,
       market.pk,
       newEventStartTime,

--- a/tests/npm-admin-client/market_management.ts
+++ b/tests/npm-admin-client/market_management.ts
@@ -18,6 +18,8 @@ import {
   voidMarket,
   openMarket,
   transferMarketEscrowSurplus,
+  updateMarketEventStarttime,
+  setMarketEventStartToNow,
 } from "../../npm-admin-client/src";
 import { monaco } from "../util/wrappers";
 import { createWalletWithBalance } from "../util/test_util";
@@ -150,6 +152,49 @@ describe("Set new locktime", () => {
     assert(response.success);
     assert(response.data.tnxId);
     assert.deepEqual(updatedMarket.marketLockTimestamp, new BN(newLocktime));
+  });
+});
+
+describe("Set new event start", () => {
+  const provider = AnchorProvider.local();
+  setProvider(provider);
+  const newEventStartTime = 1000 + Math.floor(new Date().getTime() / 1000);
+
+  it("Sets provided event start time", async () => {
+    const protocolProgram = workspace.MonacoProtocol as Program;
+    const market = await monaco.create3WayMarket([1.001]);
+    const response = await updateMarketEventStarttime(
+      protocolProgram,
+      market.pk,
+      newEventStartTime,
+    );
+    const updatedMarket = await monaco.fetchMarket(market.pk);
+
+    assert.deepEqual(response.errors, []);
+    assert(response.success);
+    assert(response.data.tnxId);
+    assert.deepEqual(
+      updatedMarket.eventStartTimestamp,
+      new BN(newEventStartTime),
+    );
+  });
+});
+
+describe("Set new event start to now", () => {
+  const provider = AnchorProvider.local();
+  setProvider(provider);
+
+  it("Sets provided event start time", async () => {
+    const protocolProgram = workspace.MonacoProtocol as Program;
+    const market = await monaco.create3WayMarket([1.001]);
+    const response = await setMarketEventStartToNow(protocolProgram, market.pk);
+    const updatedMarket = await monaco.fetchMarket(market.pk);
+
+    assert.deepEqual(response.errors, []);
+    assert(response.success);
+    assert(response.data.tnxId);
+    // Asserting the eventStart time changed need to add in assert for more accurate time check
+    assert(updatedMarket.eventStartTimestamp != new BN(1924254038));
   });
 });
 


### PR DESCRIPTION
This PR adds 2 new endpoints to the admin client:

- `updateMarketEventStartTime`
  - Set the event start time on a market to the specified `EpochTimeStamp`
- `setMarketEventStartToNow`
  - Set the event start time on a market to `now`
   

