### PR TITLE
fix: market inplay transition issue

### DIFF
--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -126,7 +126,7 @@ pub fn initialize_market_matching_pool(
     matching_pool.liquidity_amount = 0_u64;
     matching_pool.matched_amount = 0_u64;
     matching_pool.orders = Cirque::new(MarketMatchingPool::QUEUE_LENGTH);
-    matching_pool.inplay = market.inplay;
+    matching_pool.inplay = market.is_inplay();
     Ok(())
 }
 

--- a/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
@@ -19,7 +19,7 @@ fn update_market_event_start_time_internal(
     now: i64,
 ) -> Result<()> {
     // market event start time cannot be change after market moves to inplay
-    require!(!market.inplay, CoreError::MarketAlreadyInplay);
+    require!(!market.is_inplay(), CoreError::MarketAlreadyInplay);
 
     if event_start_time < now {
         msg!(

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -58,7 +58,7 @@ pub fn update_matching_queue_with_new_order(
     market_matching_pool: &mut MarketMatchingPool,
     order_account: &Account<Order>,
 ) -> Result<()> {
-    if market.inplay {
+    if market.is_inplay() {
         update_matching_queue_with_new_inplay_order(
             market,
             market_matching_pool,
@@ -131,7 +131,7 @@ pub fn move_market_matching_pool_to_inplay(
         market.inplay_enabled,
         CoreError::MatchingMarketInplayNotEnabled
     );
-    require!(market.inplay, CoreError::MatchingMarketNotYetInplay);
+    require!(market.is_inplay(), CoreError::MatchingMarketNotYetInplay);
     require!(
         !market_matching_pool.inplay,
         CoreError::MatchingMarketMatchingPoolAlreadyInplay
@@ -151,7 +151,7 @@ pub fn updated_liquidity_with_delay_expired_orders(
         CoreError::MatchingMarketInvalidStatus
     );
     require!(
-        market.inplay && market_matching_pool.inplay,
+        market.is_inplay() && market_matching_pool.inplay,
         CoreError::MatchingMarketNotYetInplay
     );
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -26,7 +26,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
 
     let now = Clock::get().unwrap().unix_timestamp;
     require!(
-        !ctx.accounts.market.inplay || order.delay_expiration_timestamp <= now,
+        !ctx.accounts.market.is_inplay() || order.delay_expiration_timestamp <= now,
         CoreError::InplayDelay
     );
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -17,7 +17,7 @@ pub fn cancel_preplay_order_post_event_start(
         [MarketStatus::Open].contains(&market.market_status),
         CoreError::CancelationMarketStatusInvalid
     );
-    require!(market.inplay, CoreError::CancelationMarketNotInplay);
+    require!(market.is_inplay(), CoreError::CancelationMarketNotInplay);
     require!(
         MarketOrderBehaviour::CancelUnmatched.eq(&market.event_start_order_behaviour),
         CoreError::CancelationMarketOrderBehaviourInvalid

--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -90,7 +90,7 @@ fn initialize_order(
     order.stake = data.stake;
     order.expected_price = data.price;
     order.creation_timestamp = now;
-    order.delay_expiration_timestamp = match market.inplay {
+    order.delay_expiration_timestamp = match market.is_inplay() {
         true => now
             .checked_add(market.inplay_order_delay as i64)
             .ok_or(CoreError::ArithmeticError),

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -64,6 +64,12 @@ impl Market {
             .ok_or(CoreError::ArithmeticError)?;
         Ok(self.market_outcomes_count)
     }
+
+    pub fn is_inplay(&self) -> bool {
+        self.inplay
+            || (self.inplay_enabled
+                && self.event_start_timestamp <= Clock::get().unwrap().unix_timestamp)
+    }
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -1,6 +1,7 @@
 use crate::error::CoreError;
 use crate::state::type_size::*;
 use anchor_lang::prelude::*;
+use solana_program::clock::UnixTimestamp;
 use std::string::ToString;
 
 #[account]
@@ -66,9 +67,11 @@ impl Market {
     }
 
     pub fn is_inplay(&self) -> bool {
-        self.inplay
-            || (self.inplay_enabled
-                && self.event_start_timestamp <= Clock::get().unwrap().unix_timestamp)
+        Market::market_is_inplay(self, Clock::get().unwrap().unix_timestamp)
+    }
+
+    pub fn market_is_inplay(market: &Market, now: UnixTimestamp) -> bool {
+        market.inplay || (market.inplay_enabled && market.event_start_timestamp <= now)
     }
 }
 
@@ -344,6 +347,141 @@ impl Cirque {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Market account tests
+
+    #[test]
+    fn test_is_inplay_inplay_true() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let market: Market = Market {
+            authority: Pubkey::default(),
+            event_account: Pubkey::default(),
+            mint_account: Pubkey::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: true,
+            inplay: true,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            escrow_account_bump: 0,
+            event_start_timestamp: now + 1000,
+        };
+
+        assert!(Market::market_is_inplay(&market, now));
+    }
+
+    #[test]
+    fn test_is_inplay_inplay_false_event_not_started() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let market: Market = Market {
+            authority: Pubkey::default(),
+            event_account: Pubkey::default(),
+            mint_account: Pubkey::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: true,
+            inplay: false,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            escrow_account_bump: 0,
+            event_start_timestamp: now + 1000,
+        };
+
+        assert!(!Market::market_is_inplay(&market, now));
+    }
+
+    #[test]
+    fn test_is_inplay_inplay_false_event_started() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let market: Market = Market {
+            authority: Pubkey::default(),
+            event_account: Pubkey::default(),
+            mint_account: Pubkey::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: true,
+            inplay: false,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            escrow_account_bump: 0,
+            event_start_timestamp: now,
+        };
+
+        assert!(Market::market_is_inplay(&market, now));
+    }
+
+    #[test]
+    fn test_is_inplay_inplay_false_event_started_not_inplay_market() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let market: Market = Market {
+            authority: Pubkey::default(),
+            event_account: Pubkey::default(),
+            mint_account: Pubkey::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: false,
+            inplay: false,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            escrow_account_bump: 0,
+            event_start_timestamp: now,
+        };
+
+        assert!(!Market::market_is_inplay(&market, now))
+    }
+
+    //
+    // Cirque tests
+    //
 
     // front < back (queue can be compared with normal array)
 

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -50,7 +50,6 @@ describe("End to end test of", () => {
 
     // Move start time up to now
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     // Create an inplay order before the market inplay flag has been updated
     let matchingPool;

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -36,7 +36,10 @@ describe("End to end test of", () => {
     const prePlayOrder03 = await market.forOrder(0, 1, 2.0, purchaser);
 
     // No liquidity, no matches
-    const prePlayOrder11 = await market.forOrder(1, 1, 2.0, purchaser);
+    const prePlayOrder10 = await market.forOrder(1, 1, 2.0, purchaser);
+
+    // Additional order to be placed after event start time but before market is moved to inplay
+    const prePlayOrder11 = await market.forOrder(1, 1, 3.0, purchaser);
 
     try {
       await market.moveMarketToInplay();
@@ -45,16 +48,28 @@ describe("End to end test of", () => {
       assert.equal(e.error.errorCode.code, "MarketEventNotStarted");
     }
 
-    // FIXME could be replaced with a call to market.setEventStartTimestampToNow()
-    while (Math.floor(new Date().getTime() / 1000) <= eventStartTimestamp + 5) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
+    // Move start time up to now
+    await market.updateMarketEventStartTimeToNow();
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Create an inplay order before the market inplay flag has been updated
+    let matchingPool;
+    try {
+      matchingPool = await market.getForMatchingPool(1, 3.0);
+      assert.deepEqual(matchingPool, { len: 1, liquidity: 1, matched: 0 });
+      await market.forOrder(1, 4.2, 3.0, purchaser);
+      matchingPool = await market.getForMatchingPool(1, 3.0);
+      assert.deepEqual(matchingPool, { len: 1, liquidity: 0, matched: 0 });
+    } catch (e) {
+      console.log(e);
+      throw e;
     }
 
     await market.moveMarketToInplay();
 
     // 1. Inplay order into existing non-zero'd preplay matching pool
     // With existing liquidity
-    let matchingPool = await market.getForMatchingPool(0, 2.0);
+    matchingPool = await market.getForMatchingPool(0, 2.0);
     assert.equal(matchingPool.liquidity, 1);
 
     await market.forOrder(0, 1, 2.0, purchaser);
@@ -108,6 +123,7 @@ describe("End to end test of", () => {
     await market.processDelayExpiredOrders(0, 2.0, true);
     await market.processDelayExpiredOrders(0, 2.0, false);
     await market.processDelayExpiredOrders(1, 2.0, true);
+    await market.processDelayExpiredOrders(1, 3.0, true);
     await market.processDelayExpiredOrders(2, 2.0, true);
     // Skip processing this matching pool and allow matching to use the delay expired order
     // await market.processDelayExpiredOrders(2, 2.0, false);
@@ -120,6 +136,9 @@ describe("End to end test of", () => {
 
     matchingPool = await market.getForMatchingPool(1, 2.0);
     assert.equal(matchingPool.liquidity, 1);
+
+    matchingPool = await market.getForMatchingPool(1, 3.0);
+    assert.equal(matchingPool.liquidity, 4.2);
 
     matchingPool = await market.getForMatchingPool(2, 2.0);
     assert.equal(matchingPool.liquidity, 1);
@@ -142,6 +161,7 @@ describe("End to end test of", () => {
     await market.cancelPreplayOrderPostEventStart(prePlayOrder01);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder02);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder03);
+    await market.cancelPreplayOrderPostEventStart(prePlayOrder10);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder11);
 
     order = await monaco.getOrder(prePlayOrder01);
@@ -150,7 +170,7 @@ describe("End to end test of", () => {
     assert.equal(order.stakeUnmatched, 0);
     order = await monaco.getOrder(prePlayOrder03);
     assert.equal(order.stakeUnmatched, 0);
-    order = await monaco.getOrder(prePlayOrder11);
+    order = await monaco.getOrder(prePlayOrder10);
     assert.equal(order.stakeUnmatched, 0);
 
     // Settle market and market positions and orders

--- a/tests/protocol/cancel_preplay_order_post_event_start.ts
+++ b/tests/protocol/cancel_preplay_order_post_event_start.ts
@@ -9,8 +9,6 @@ import {
 } from "../util/test_util";
 import { Monaco, monaco } from "../util/wrappers";
 
-const moveMarketToInplayDelay = 1500;
-
 // Order parameters
 const outcomeIndex = 1;
 const price = 6.0;
@@ -28,7 +26,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -68,7 +65,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -108,7 +104,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -163,7 +158,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
     await market.settle(outcomeIndex);
 
@@ -207,7 +201,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
 
     try {
       await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -227,7 +220,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     // Create Order after event start time

--- a/tests/protocol/create_order.ts
+++ b/tests/protocol/create_order.ts
@@ -892,7 +892,6 @@ describe("Protocol - Create Order", () => {
     assert.equal(matchingPool.liquidity, 10);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
 
     await market.forOrder(0, 1, 2.0, purchaser);
@@ -929,7 +928,6 @@ describe("Protocol - Create Order", () => {
     assert.equal(matchingPool.liquidity, 10);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
 
     await market.forOrder(0, 1, 2.0, purchaser);

--- a/tests/protocol/move_market_matching_pool_to_inplay.ts
+++ b/tests/protocol/move_market_matching_pool_to_inplay.ts
@@ -28,7 +28,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.inplay, false);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 
@@ -61,7 +60,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.matched, 0);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 
@@ -96,7 +94,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.matched, 0);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 


### PR DESCRIPTION
Fixes #81 

This addresses the issue raised in #81 ,  updating the protocol to not rely only on a market's `inplay` flag to determine whether the market is in play/in running/live yet, but rather will fall back on checking the market's event start timestamp also. 

```Rust
market.inplay || (market.inplay_enabled && market.event_start_timestamp <= now)
```

This change now means that orders placed on or after a market's event start timestamp will be treated properly as inplay orders - triggering an orderbook reset if the market is configured to do so - and will no longer be considered to be included in or matched against pre-event start liquidity. 