### PR TITLE
fix: transition matching pools asap, don't leave pool inconsistent 

### DIFF
--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -11,6 +11,7 @@ pub fn cancel_preplay_order_post_event_start(
 ) -> Result<()> {
     let order = &ctx.accounts.order;
     let market = &ctx.accounts.market;
+    let market_matching_pool = &mut ctx.accounts.market_matching_pool;
 
     // market is open + in inplay mode + and cancellation is the intended behaviour
     require!(
@@ -32,6 +33,10 @@ pub fn cancel_preplay_order_post_event_start(
         order.creation_timestamp < market.event_start_timestamp,
         CoreError::CancelationOrderCreatedAfterMarketEventStarted
     );
+
+    if !market_matching_pool.inplay {
+        market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+    }
 
     ctx.accounts.order.void_stake_unmatched();
 

--- a/tests/protocol/cancel_preplay_order_post_event_start.ts
+++ b/tests/protocol/cancel_preplay_order_post_event_start.ts
@@ -47,6 +47,12 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
         10000,
       ],
     );
+
+    const marketMatchingPool =
+      await monaco.program.account.marketMatchingPool.fetch(
+        market.matchingPools[outcomeIndex][price].forOutcome,
+      );
+    assert.ok(marketMatchingPool.inplay);
   });
 
   it("success: partially matched order", async () => {


### PR DESCRIPTION
After a cancellation if the matching/liquidity pool isn't transitioned to inplay already then the pool isn't updated to reflect the cancelled order and looks like it still contains pre-event liquidity even though at least some of that liquidity has been refunded.

This change will reset the pool, transitioning it for inplay, during the first order cancellation if it hasn't been transitioned already. This will remove the chance for the pool to be inconsistent and showing no-longer available liquidity. 