### PR TITLE
fix: reduce product commission where total commission exceeds profit

### DIFF
--- a/programs/monaco_protocol/src/instructions/math.rs
+++ b/programs/monaco_protocol/src/instructions/math.rs
@@ -41,6 +41,16 @@ pub fn calculate_commission(commission_rate: f64, profit: i128) -> u64 {
         .unwrap()
 }
 
+pub fn calculate_post_commission_remainder(commission_rate: f64, profit: i128) -> u64 {
+    let commission_rate_decimal = Decimal::from_f64(commission_rate).unwrap();
+    let profit_decimal = Decimal::from(profit);
+    let commission_decimal = profit_decimal
+        .max(Decimal::ZERO)
+        .mul(commission_rate_decimal)
+        .div(Decimal::ONE_HUNDRED);
+    profit_decimal.sub(commission_decimal).to_u64().unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/programs/monaco_protocol/src/instructions/math.rs
+++ b/programs/monaco_protocol/src/instructions/math.rs
@@ -32,9 +32,12 @@ pub fn stake_precision_is_within_range(stake: u64, decimal_limit: u8) -> bool {
 }
 
 pub fn calculate_commission(commission_rate: f64, profit: i128) -> u64 {
+    if profit <= 0 || commission_rate == 0.0 {
+        return 0;
+    }
+
     let commission_rate_decimal = Decimal::from_f64(commission_rate).unwrap();
     Decimal::from(profit)
-        .max(Decimal::ZERO)
         .mul(commission_rate_decimal)
         .div(Decimal::ONE_HUNDRED)
         .to_u64()
@@ -42,10 +45,13 @@ pub fn calculate_commission(commission_rate: f64, profit: i128) -> u64 {
 }
 
 pub fn calculate_post_commission_remainder(commission_rate: f64, profit: i128) -> u64 {
+    if profit <= 0 || commission_rate == 0.0 {
+        return 0;
+    }
+
     let commission_rate_decimal = Decimal::from_f64(commission_rate).unwrap();
     let profit_decimal = Decimal::from(profit);
     let commission_decimal = profit_decimal
-        .max(Decimal::ZERO)
         .mul(commission_rate_decimal)
         .div(Decimal::ONE_HUNDRED);
     profit_decimal.sub(commission_decimal).to_u64().unwrap()

--- a/programs/monaco_protocol/src/instructions/math.rs
+++ b/programs/monaco_protocol/src/instructions/math.rs
@@ -45,7 +45,7 @@ pub fn calculate_commission(commission_rate: f64, profit: i128) -> u64 {
 }
 
 pub fn calculate_post_commission_remainder(commission_rate: f64, profit: i128) -> u64 {
-    if profit <= 0 || commission_rate == 0.0 {
+    if profit <= 0 {
         return 0;
     }
 
@@ -119,5 +119,16 @@ mod tests {
         // 1000000 = 1 @ 6 mint decimals
         assert_eq!(calculate_commission(1.00, 1000000), 10000);
         assert_eq!(calculate_commission(33.33, 1000000), 333300);
+    }
+
+    #[test]
+    fn calculate_post_commission_remainder_zero_protocol_commission() {
+        let profit = 100;
+        let commission_rate = 0.0;
+
+        assert_eq!(
+            profit as u64,
+            calculate_post_commission_remainder(commission_rate, profit)
+        );
     }
 }


### PR DESCRIPTION
Currently if total commisison exceeds profit there is a chance that product commission will be over-charged. With this fix we ensure that product profit can not exceed the total amount of available profit.