### PR TITLE
chore: set admin client version for 0.10.0 protocol release

### DIFF
--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",


### PR DESCRIPTION
Unfortunately version 5.0.0 was lost to us. 