### PR TITLE
release: 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.10.0"
+version = "0.10.1"
 description = "Created with Anchor"
 edition = "2018"
 

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -126,7 +126,7 @@ pub fn initialize_market_matching_pool(
     matching_pool.liquidity_amount = 0_u64;
     matching_pool.matched_amount = 0_u64;
     matching_pool.orders = Cirque::new(MarketMatchingPool::QUEUE_LENGTH);
-    matching_pool.inplay = market.inplay;
+    matching_pool.inplay = market.is_inplay();
     Ok(())
 }
 

--- a/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
@@ -19,7 +19,7 @@ fn update_market_event_start_time_internal(
     now: i64,
 ) -> Result<()> {
     // market event start time cannot be change after market moves to inplay
-    require!(!market.inplay, CoreError::MarketAlreadyInplay);
+    require!(!market.is_inplay(), CoreError::MarketAlreadyInplay);
 
     if event_start_time < now {
         msg!(

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -58,7 +58,7 @@ pub fn update_matching_queue_with_new_order(
     market_matching_pool: &mut MarketMatchingPool,
     order_account: &Account<Order>,
 ) -> Result<()> {
-    if market.inplay {
+    if market.is_inplay() {
         update_matching_queue_with_new_inplay_order(
             market,
             market_matching_pool,
@@ -131,7 +131,7 @@ pub fn move_market_matching_pool_to_inplay(
         market.inplay_enabled,
         CoreError::MatchingMarketInplayNotEnabled
     );
-    require!(market.inplay, CoreError::MatchingMarketNotYetInplay);
+    require!(market.is_inplay(), CoreError::MatchingMarketNotYetInplay);
     require!(
         !market_matching_pool.inplay,
         CoreError::MatchingMarketMatchingPoolAlreadyInplay
@@ -151,7 +151,7 @@ pub fn updated_liquidity_with_delay_expired_orders(
         CoreError::MatchingMarketInvalidStatus
     );
     require!(
-        market.inplay && market_matching_pool.inplay,
+        market.is_inplay() && market_matching_pool.inplay,
         CoreError::MatchingMarketNotYetInplay
     );
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -26,7 +26,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
 
     let now = Clock::get().unwrap().unix_timestamp;
     require!(
-        !ctx.accounts.market.inplay || order.delay_expiration_timestamp <= now,
+        !ctx.accounts.market.is_inplay() || order.delay_expiration_timestamp <= now,
         CoreError::InplayDelay
     );
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -18,7 +18,7 @@ pub fn cancel_preplay_order_post_event_start(
         [MarketStatus::Open].contains(&market.market_status),
         CoreError::CancelationMarketStatusInvalid
     );
-    require!(market.inplay, CoreError::CancelationMarketNotInplay);
+    require!(market.is_inplay(), CoreError::CancelationMarketNotInplay);
     require!(
         MarketOrderBehaviour::CancelUnmatched.eq(&market.event_start_order_behaviour),
         CoreError::CancelationMarketOrderBehaviourInvalid

--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -90,7 +90,7 @@ fn initialize_order(
     order.stake = data.stake;
     order.expected_price = data.price;
     order.creation_timestamp = now;
-    order.delay_expiration_timestamp = match market.inplay {
+    order.delay_expiration_timestamp = match market.is_inplay() {
         true => now
             .checked_add(market.inplay_order_delay as i64)
             .ok_or(CoreError::ArithmeticError),

--- a/tests/protocol/cancel_preplay_order_post_event_start.ts
+++ b/tests/protocol/cancel_preplay_order_post_event_start.ts
@@ -9,8 +9,6 @@ import {
 } from "../util/test_util";
 import { Monaco, monaco } from "../util/wrappers";
 
-const moveMarketToInplayDelay = 1500;
-
 // Order parameters
 const outcomeIndex = 1;
 const price = 6.0;
@@ -28,7 +26,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -74,7 +71,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -114,7 +110,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -169,7 +164,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
     await market.settle(outcomeIndex);
 
@@ -213,7 +207,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
 
     try {
       await market.cancelPreplayOrderPostEventStart(orderPk);
@@ -233,7 +226,6 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
 
     // Update Market's evenet start time
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((e) => setTimeout(e, moveMarketToInplayDelay));
     await market.moveMarketToInplay();
 
     // Create Order after event start time

--- a/tests/protocol/create_order.ts
+++ b/tests/protocol/create_order.ts
@@ -892,7 +892,6 @@ describe("Protocol - Create Order", () => {
     assert.equal(matchingPool.liquidity, 10);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
 
     await market.forOrder(0, 1, 2.0, purchaser);
@@ -929,7 +928,6 @@ describe("Protocol - Create Order", () => {
     assert.equal(matchingPool.liquidity, 10);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
 
     await market.forOrder(0, 1, 2.0, purchaser);

--- a/tests/protocol/move_market_matching_pool_to_inplay.ts
+++ b/tests/protocol/move_market_matching_pool_to_inplay.ts
@@ -28,7 +28,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.inplay, false);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 
@@ -61,7 +60,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.matched, 0);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 
@@ -96,7 +94,6 @@ describe("Protocol - Move market matching pool to inplay", () => {
     assert.equal(matchingPool.matched, 0);
 
     await market.updateMarketEventStartTimeToNow();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await market.moveMarketToInplay();
     await market.moveMarketMatchingPoolToInplay(0, 2.0, true);
 


### PR DESCRIPTION
fix: market inplay transition issue (see full details on #82)
* This addresses the issue raised in https://github.com/MonacoProtocol/protocol/issues/81 , updating the protocol to not rely only on a market's inplay flag to determine whether the market is in play/in running/live yet, but rather will fall back on checking the market's event start timestamp also.