### PR TITLE
fix: allow unittests to use clock time

### DIFF
--- a/programs/monaco_protocol/src/instructions/clock.rs
+++ b/programs/monaco_protocol/src/instructions/clock.rs
@@ -1,0 +1,16 @@
+pub fn current_timestamp() -> i64 {
+    #[cfg(not(test))]
+    {
+        use solana_program::clock::Clock;
+        use solana_program::sysvar::Sysvar;
+        Clock::get().unwrap().unix_timestamp
+    }
+    #[cfg(test)]
+    {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+}

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -3,6 +3,7 @@ use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 
 use crate::context::{CreateMarket, InitializeMarketOutcome};
+use crate::instructions::current_timestamp;
 use crate::monaco_protocol::PRICE_SCALE;
 use crate::state::market_account::{
     Cirque, Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome, MarketStatus,
@@ -28,7 +29,7 @@ pub fn create(
         CoreError::MarketTitleTooLong
     );
     require!(
-        market_lock_timestamp > Clock::get().unwrap().unix_timestamp,
+        market_lock_timestamp > current_timestamp(),
         CoreError::MarketLockTimeNotInTheFuture
     );
     require!(
@@ -67,7 +68,7 @@ pub fn create(
         0
     };
     ctx.accounts.market.inplay = if inplay_enabled {
-        event_start_timestamp <= Clock::get().unwrap().unix_timestamp
+        event_start_timestamp <= current_timestamp()
     } else {
         false
     };

--- a/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
@@ -1,15 +1,16 @@
 use anchor_lang::prelude::*;
 
 use crate::error::CoreError;
+use crate::instructions::current_timestamp;
 use crate::state::market_account::Market;
 
 pub fn update_market_event_start_time(market: &mut Market, event_start_time: i64) -> Result<()> {
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     update_market_event_start_time_internal(market, event_start_time, now)
 }
 
 pub fn update_market_event_start_time_to_now(market: &mut Market) -> Result<()> {
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     update_market_event_start_time_internal(market, now, now)
 }
 

--- a/programs/monaco_protocol/src/instructions/market/update_market_locktime.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_locktime.rs
@@ -1,10 +1,9 @@
 use anchor_lang::prelude::*;
-use solana_program::clock::Clock;
 use solana_program::msg;
-use solana_program::sysvar::Sysvar;
 
 use crate::context::UpdateMarket;
 use crate::error::CoreError;
+use crate::instructions::current_timestamp;
 use crate::state::market_account::Market;
 
 pub fn update_locktime(ctx: Context<UpdateMarket>, lock_time: i64) -> Result<()> {
@@ -15,7 +14,7 @@ pub fn update_locktime(ctx: Context<UpdateMarket>, lock_time: i64) -> Result<()>
         CoreError::MarketLockTimeAfterEventStartTime
     );
 
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     update_market_locktime(market, lock_time, now)
 }
 

--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -1,11 +1,11 @@
 use anchor_lang::prelude::*;
-use solana_program::clock::Clock;
-use solana_program::sysvar::Sysvar;
 
 use crate::context::MatchOrders;
 use crate::error::CoreError;
 use crate::instructions::matching::create_trade::initialize_trade;
-use crate::instructions::{calculate_risk_from_stake, matching, order, transfer};
+use crate::instructions::{
+    calculate_risk_from_stake, current_timestamp, matching, order, transfer,
+};
 use crate::state::market_account::MarketStatus::Open;
 use crate::state::market_position_account::{MarketPosition, ProductMatchedRiskAndRate};
 use crate::state::order_account::Order;
@@ -20,7 +20,7 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
         CoreError::MarketNotOpen,
     );
 
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     require!(
         ctx.accounts.market.market_lock_timestamp > now,
         CoreError::MarketLocked
@@ -143,7 +143,7 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
     }
 
     // 5. Initialize the trade accounts
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     initialize_trade(
         &mut ctx.accounts.trade_against,
         &ctx.accounts.order_against,

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use solana_program::clock::UnixTimestamp;
 
+use crate::instructions::current_timestamp;
 use crate::state::market_account::{Market, MarketStatus, QueueItem};
 use crate::{CoreError, MarketMatchingPool, MarketOutcome, Order};
 
@@ -155,7 +156,7 @@ pub fn updated_liquidity_with_delay_expired_orders(
         CoreError::MatchingMarketNotYetInplay
     );
 
-    let now: UnixTimestamp = Clock::get().unwrap().unix_timestamp;
+    let now: UnixTimestamp = current_timestamp();
     for i in 0..market_matching_pool.orders.len() {
         if let Some(order) = market_matching_pool.orders.peek(i) {
             if order.delay_expiration_timestamp > now {
@@ -190,7 +191,7 @@ fn update_matching_queue_with_matched_order(
                 CoreError::OrderNotAtFrontOfQueue
             );
             if queue_item.liquidity_to_add > 0 {
-                let now: UnixTimestamp = Clock::get().unwrap().unix_timestamp;
+                let now: UnixTimestamp = current_timestamp();
                 if queue_item.delay_expiration_timestamp <= now {
                     matching_pool.liquidity_amount = matching_pool
                         .liquidity_amount

--- a/programs/monaco_protocol/src/instructions/mod.rs
+++ b/programs/monaco_protocol/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub use account::*;
+pub use clock::*;
 pub use math::*;
 pub use operator::*;
 pub use payment::*;
@@ -10,6 +11,7 @@ pub(crate) mod matching;
 pub(crate) mod order;
 
 mod account;
+mod clock;
 mod math;
 mod operator;
 mod payment;

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::context::CancelOrder;
 use crate::error::CoreError;
-use crate::instructions::{account, market_position, matching, transfer};
+use crate::instructions::{account, current_timestamp, market_position, matching, transfer};
 use crate::state::market_account::MarketStatus;
 use crate::state::order_account::*;
 
@@ -24,7 +24,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         CoreError::CancelOrderNotCancellable
     );
 
-    let now = Clock::get().unwrap().unix_timestamp;
+    let now = current_timestamp();
     require!(
         !ctx.accounts.market.is_inplay() || order.delay_expiration_timestamp <= now,
         CoreError::InplayDelay

--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -5,7 +5,7 @@ use solana_program::clock::UnixTimestamp;
 
 use crate::error::CoreError;
 use crate::instructions::math::stake_precision_is_within_range;
-use crate::instructions::{market, market_position, matching, transfer};
+use crate::instructions::{current_timestamp, market, market_position, matching, transfer};
 use crate::state::market_account::*;
 use crate::state::market_position_account::MarketPosition;
 use crate::state::order_account::*;
@@ -56,7 +56,7 @@ fn initialize_order(
     product: &Option<Account<Product>>,
     data: OrderData,
 ) -> Result<()> {
-    let now: UnixTimestamp = Clock::get().unwrap().unix_timestamp;
+    let now: UnixTimestamp = current_timestamp();
     validate_market_for_order(market, now)?;
 
     // validate

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -29,6 +29,7 @@ declare_id!("monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih");
 #[program]
 pub mod monaco_protocol {
     use super::*;
+    use crate::instructions::current_timestamp;
 
     pub const PRICE_SCALE: u8 = 3_u8;
 
@@ -384,7 +385,7 @@ pub mod monaco_protocol {
     }
 
     pub fn move_market_to_inplay(ctx: Context<UpdateMarketUnauthorized>) -> Result<()> {
-        let now = Clock::get().unwrap().unix_timestamp;
+        let now = current_timestamp();
         let market = &mut ctx.accounts.market;
 
         // market must have inplay enabled
@@ -427,7 +428,7 @@ pub mod monaco_protocol {
             &ctx.accounts.market.authority,
         )?;
 
-        let settle_time = Clock::get().unwrap().unix_timestamp;
+        let settle_time = current_timestamp();
         instructions::market::settle(&mut ctx.accounts.market, winning_outcome_index, settle_time)
     }
 
@@ -450,7 +451,7 @@ pub mod monaco_protocol {
             &ctx.accounts.market.authority,
         )?;
 
-        let void_time = Clock::get().unwrap().unix_timestamp;
+        let void_time = current_timestamp();
         instructions::market::void(&mut ctx.accounts.market, void_time)
     }
 

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -1,4 +1,5 @@
 use crate::error::CoreError;
+use crate::instructions::current_timestamp;
 use crate::state::type_size::*;
 use anchor_lang::prelude::*;
 use solana_program::clock::UnixTimestamp;
@@ -67,7 +68,7 @@ impl Market {
     }
 
     pub fn is_inplay(&self) -> bool {
-        Market::market_is_inplay(self, Clock::get().unwrap().unix_timestamp)
+        Market::market_is_inplay(self, current_timestamp())
     }
 
     pub fn market_is_inplay(market: &Market, now: UnixTimestamp) -> bool {


### PR DESCRIPTION
Enables functions that rely on clock time to be united tested. The Clock sysvar which is used when running on the solana runtime to get the current time is not available when running `cargo test`. This changes enables the use of SystemTime when running `cargo test` but otherwise uses the `Clock` sysvar to get the current timestamp.