### PR TITLE
refactor: remove all hardcoded commitment levels from client

### DIFF
--- a/npm-admin-client/src/market_helpers.ts
+++ b/npm-admin-client/src/market_helpers.ts
@@ -277,7 +277,6 @@ export class MarketOutcomes {
       const accountsWithData =
         (await this.program.account.marketOutcome.fetchMultiple(
           accountPublicKeys.data.publicKeys,
-          "confirmed",
         )) as MarketOutcomeAccount[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-admin-client/src/market_outcome_prices.ts
+++ b/npm-admin-client/src/market_outcome_prices.ts
@@ -62,7 +62,7 @@ export async function addPricesToOutcome(
         authorisedOperators: authorisedOperatorsPda.data.pda,
         marketOperator: provider.wallet.publicKey,
       })
-      .rpc({ commitment: "confirmed" });
+      .rpc();
 
     response.addResponseData({
       priceLadder: priceLadder,

--- a/npm-client/src/create_order.ts
+++ b/npm-client/src/create_order.ts
@@ -123,7 +123,7 @@ export async function createOrder(
       product: productPk == undefined ? null : productPk,
     })
     .signers(provider.wallet instanceof Keypair ? [provider.wallet] : [])
-    .rpc({ commitment: "confirmed" })
+    .rpc()
     .catch((e) => {
       response.addError(e);
     });

--- a/npm-client/src/market_matching_pool_query.ts
+++ b/npm-client/src/market_matching_pool_query.ts
@@ -68,7 +68,6 @@ export class MarketMatchingPools {
       const accountsWithData =
         (await this.program.account.marketMatchingPool.fetchMultiple(
           accountPublicKeys.data.publicKeys,
-          "confirmed",
         )) as MarketMatchingPoolAccount[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-client/src/market_outcome_query.ts
+++ b/npm-client/src/market_outcome_query.ts
@@ -88,7 +88,6 @@ export class MarketOutcomes {
       const accountsWithData =
         (await this.program.account.marketOutcome.fetchMultiple(
           accountPublicKeys.data.publicKeys,
-          "confirmed",
         )) as MarketOutcomeAccount[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-client/src/market_query.ts
+++ b/npm-client/src/market_query.ts
@@ -149,7 +149,6 @@ export class Markets {
     try {
       const accountsWithData = (await this.program.account.market.fetchMultiple(
         accountPublicKeys.data.publicKeys,
-        "confirmed",
       )) as MarketAccount[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-client/src/order_query.ts
+++ b/npm-client/src/order_query.ts
@@ -140,7 +140,6 @@ export class Orders {
     try {
       const accountsWithData = (await this.program.account.order.fetchMultiple(
         accountPublicKeys.data.publicKeys,
-        "confirmed",
       )) as Order[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-client/src/product.ts
+++ b/npm-client/src/product.ts
@@ -44,7 +44,7 @@ export async function createProduct(
       systemProgram: SystemProgram.programId,
     })
     .signers(defaultAuthority ? [] : [authority])
-    .rpc({ commitment: "confirmed" })
+    .rpc()
     .catch((e) => {
       response.addError(e);
     });
@@ -87,7 +87,7 @@ export async function updateProductCommissionRate(
       product: productPk,
       authority: authorityPk,
     })
-    .rpc({ commitment: "confirmed" })
+    .rpc()
     .catch((e) => {
       response.addError(e);
     });
@@ -130,7 +130,7 @@ export async function updateProductCommissionEscrow(
       product: productPk,
       authority: authorityPk,
     })
-    .rpc({ commitment: "confirmed" })
+    .rpc()
     .catch((e) => {
       response.addError(e);
     });
@@ -175,7 +175,7 @@ export async function updateProductAuthority(
       updatedAuthority: updatedAuthoritySigner.publicKey,
     })
     .signers([updatedAuthoritySigner])
-    .rpc({ commitment: "confirmed" })
+    .rpc()
     .catch((e) => {
       response.addError(e);
     });

--- a/npm-client/src/product_query.ts
+++ b/npm-client/src/product_query.ts
@@ -89,7 +89,6 @@ export class Products {
       const accountsWithData =
         (await this.program.account.product.fetchMultiple(
           accountPublicKeys.data.publicKeys,
-          "confirmed",
         )) as Product[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/npm-client/src/trade_query.ts
+++ b/npm-client/src/trade_query.ts
@@ -105,7 +105,6 @@ export class Trades {
     try {
       const accountsWithData = (await this.program.account.trade.fetchMultiple(
         accountPublicKeys.data.publicKeys,
-        "confirmed",
       )) as Trade[];
 
       const result = accountPublicKeys.data.publicKeys

--- a/tests/protocol/create_order.ts
+++ b/tests/protocol/create_order.ts
@@ -281,7 +281,7 @@ describe("Protocol - Create Order", () => {
         marketEscrow: MarketAccounts.data.escrowPda,
         product: null,
       })
-      .rpc({ commitment: "confirmed" })
+      .rpc()
       .catch((e) => {
         assert.equal(e.error.errorCode.code, "ConstraintSeeds");
       });

--- a/tests/util/test_util.ts
+++ b/tests/util/test_util.ts
@@ -204,7 +204,6 @@ export async function createMarket(
       marketOperator.publicKey,
       1000000000,
     ),
-    "confirmed",
   );
 
   const eventAccount = anchor.web3.Keypair.generate();
@@ -281,7 +280,6 @@ export async function createMarket(
           console.error(e);
           throw e;
         }),
-      "confirmed",
     );
 
     const priceLadderBatchSize = 20;
@@ -303,7 +301,6 @@ export async function createMarket(
             console.error(e);
             throw e;
           }),
-        "confirmed",
       );
     }
   }
@@ -367,7 +364,6 @@ export async function authoriseAdminOperator(
         systemProgram: SystemProgram.programId,
       })
       .rpc(),
-    "confirmed",
   );
 
   return authorisedOperatorsPk;
@@ -426,7 +422,6 @@ export async function createWalletWithBalance(
   const payer = Keypair.generate();
   await provider.connection.confirmTransaction(
     await provider.connection.requestAirdrop(payer.publicKey, lamportBalance),
-    "confirmed",
   );
   return payer;
 }

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -40,14 +40,13 @@ export let monaco: Monaco;
 export let externalPrograms: ExternalPrograms;
 
 beforeAll(async () => {
+  const provider = anchor.AnchorProvider.local();
+
   // Programs
-  monaco = new Monaco(
-    anchor.getProvider() as anchor.AnchorProvider,
-    anchor.workspace.MonacoProtocol,
-  );
+  monaco = new Monaco(provider, anchor.workspace.MonacoProtocol);
 
   externalPrograms = new ExternalPrograms(
-    anchor.getProvider() as anchor.AnchorProvider,
+    provider,
     getProtocolProductProgram(),
   );
 });
@@ -357,7 +356,6 @@ export class Monaco {
             console.error(e);
             throw e;
           }),
-        "confirmed",
       );
 
       const priceLadderBatchSize = 20;
@@ -386,7 +384,6 @@ export class Monaco {
               console.error(e);
               throw e;
             }),
-          "confirmed",
         );
       }
     }


### PR DESCRIPTION
The client code should not hardcode commitment levels when making rpc calls, it should instead rely on the provider settings

Based on: https://docs.solana.com/developing/transaction_confirmation#use-an-appropriate-preflight-commitment-level
