### PR TITLE
chore: set versions and update readme for 0.11.0 protocol release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/README.md
+++ b/README.md
@@ -18,17 +18,33 @@ The protocol is currently in beta, though it is available both on devnet and mai
 | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` | `devnet`       | `release` - The latest stable official release     |
 | `mpDEVnZKneBb4w1vQsoTgMkNqnFe1rwW8qjmf3NsrAU` | `devnet`       | `bleeding-edge` - The most recently merged changes |
 
+# Mainnet upgrades :satellite:
+
+| Date       | Protocol version                                                          | Program address                               |
+|------------|---------------------------------------------------------------------------|-----------------------------------------------|
+| 2023-MM-DD | [0.11.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.11.0) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-07-06 | [0.10.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.1) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-06-26 | [0.10.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.0) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-05-26 | [0.9.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.9.0)   | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-04-20 | [0.8.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.8.0)   | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-03-16 | [0.7.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.7.0)   | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2023-03-02 | [0.6.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.6.0)   | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+| 2022-11-25 | [0.5.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.5.0)   | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+
 # Recent releases <sup>:rocket:</sup>
 
-| Date       | Commit                                                                       | Protocol | Client       | Admin client | Audit reports                                                                      | Program address                               |
-|------------|------------------------------------------------------------------------------|----------|--------------|--------------|------------------------------------------------------------------------------------|-----------------------------------------------|
-| 2023-07-06 | [`bbc9275`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.1) | 0.10.1   | 7.1.0        | 6.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.10.1.pdf) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2023-06-26 | [`b105420`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.0) | 0.10.0   | 7.1.0        | 6.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.10.0.pdf) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2023-05-26 | [`e9402f2`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.9.0)  | 0.9.0    | 7.0.0        | 4.1.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.9.0.pdf)  | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2023-04-20 | [`84f419e`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.8.0)  | 0.8.0    | 4.x.x, 5.x.x | 3.x.x, 4.x.x | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.8.0.pdf)  | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2023-03-16 | [`6d49ace`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.7.0)  | 0.7.0    | 4.x.x        | 3.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.7.0.pdf)  | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2023-03-02 | [`4d7ad27`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.6.0)  | 0.6.0    | 3.x.x, 4.0.x | 2.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.6.0.pdf)  | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
-| 2022-11-25 | [`ac86fc5`](https://github.com/MonacoProtocol/protocol/releases/tag/v0.5.0)  | 0.5.0    | 2.0.0        | 1.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.5.0.pdf)  | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
+Protocol releases, along with their corresponding client versions and audit reports.
+
+| Protocol version                                                          | Client       | Admin client | Audit reports                                                                      |
+|---------------------------------------------------------------------------|--------------|--------------|------------------------------------------------------------------------------------|
+| [0.11.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.11.0) | 8.0.0        | 7.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.11.0.pdf) |
+| [0.10.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.1) | 7.1.0        | 6.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.10.1.pdf) |
+| [0.10.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.0) | 7.1.0        | 6.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.10.0.pdf) |
+| [0.9.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.9.0)   | 7.0.0        | 4.1.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.9.0.pdf)  |
+| [0.8.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.8.0)   | 4.x.x, 5.x.x | 3.x.x, 4.x.x | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.8.0.pdf)  |
+| [0.7.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.7.0)   | 4.x.x        | 3.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.7.0.pdf)  |
+| [0.6.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.6.0)   | 3.x.x, 4.0.x | 2.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.6.0.pdf)  |
+| [0.5.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.5.0)   | 2.0.0        | 1.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.5.0.pdf)  |
 
 # More info :books:
 

--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "7.1.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "big.js": "^6.2.1"

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.10.1"
+version = "0.11.0"
 description = "Created with Anchor"
 edition = "2018"
 


### PR DESCRIPTION
Both clients get major bumps due to tx confirmation changes.
Updated readme to split the date away from the code release so we can cut and complete the code release without worrying about the upgrade date. Code release dates are tag/github release dates anyway. 