### PR TITLE
Fix/only transition open inplay markets

### DIFF
--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -220,6 +220,8 @@ pub enum CoreError {
     MarketAlreadyInplay,
     #[msg("Market: market event not started")]
     MarketEventNotStarted,
+    #[msg("Market: market not open to allow transition to inplay")]
+    MarketNotOpenForInplay,
 
     /*
     Close Account

--- a/programs/monaco_protocol/src/instructions/market/mod.rs
+++ b/programs/monaco_protocol/src/instructions/market/mod.rs
@@ -1,6 +1,7 @@
 mod create_market;
 mod escrow;
 mod market_authority;
+mod move_to_inplay;
 mod update_market_event_start_time;
 mod update_market_locktime;
 mod update_market_status;
@@ -9,6 +10,7 @@ mod update_market_title;
 pub use create_market::*;
 pub use escrow::*;
 pub use market_authority::*;
+pub use move_to_inplay::*;
 pub use update_market_event_start_time::*;
 pub use update_market_locktime::*;
 pub use update_market_status::*;

--- a/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
+++ b/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
@@ -1,0 +1,133 @@
+use anchor_lang::prelude::*;
+
+use crate::error::CoreError;
+use crate::instructions::current_timestamp;
+use crate::state::market_account::Market;
+use crate::state::market_account::MarketStatus::Open;
+
+pub fn move_market_to_inplay(market: &mut Market) -> Result<()> {
+    let now = current_timestamp();
+
+    require!(
+        Open.eq(&market.market_status),
+        CoreError::MarketNotOpenForInplay
+    );
+
+    // market must have inplay enabled
+    require!(market.inplay_enabled, CoreError::MarketInplayNotEnabled);
+
+    // set it `true` only if it's `false`
+    require!(!market.inplay, CoreError::MarketAlreadyInplay);
+
+    // set it `true` only if now is after event start
+    require!(
+        market.event_start_timestamp <= now,
+        CoreError::MarketEventNotStarted,
+    );
+
+    market.inplay = true;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::instructions::current_timestamp;
+    use crate::instructions::market::move_market_to_inplay;
+    use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
+
+    use crate::state::market_type::EVENT_RESULT_WINNER;
+
+    fn market_setup() -> Market {
+        let market = Market {
+            authority: Default::default(),
+            event_account: Default::default(),
+            mint_account: Default::default(),
+            decimal_limit: 2,
+            market_outcomes_count: 3_u16,
+            market_winning_outcome_index: Some(1),
+            market_type: String::from(EVENT_RESULT_WINNER),
+            market_settle_timestamp: None,
+            title: "".to_string(),
+            market_status: MarketStatus::Open,
+            escrow_account_bump: 0,
+            published: false,
+            suspended: false,
+            inplay_order_delay: 0,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_timestamp: current_timestamp() + 1000000001,
+            event_start_timestamp: current_timestamp() - 1000000000,
+            inplay_enabled: true,
+            inplay: false,
+        };
+        return market;
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_success() {
+        let mut market: Market = market_setup();
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_failure_not_inplay() {
+        let mut market: Market = market_setup();
+        market.inplay_enabled = false;
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("market inplay not enabled"));
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_not_started() {
+        let mut market: Market = market_setup();
+        market.event_start_timestamp = current_timestamp() + 1000000000;
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("market event not started"));
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_failure_already_inplay() {
+        let mut market: Market = market_setup();
+        market.inplay = true;
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("market is already inplay"));
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_failure_market_not_open_initializing() {
+        let mut market: Market = market_setup();
+        market.market_status = MarketStatus::Initializing;
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("market not open to allow transition to inplay"));
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_failure_market_not_open_settled() {
+        let mut market: Market = market_setup();
+        market.market_status = MarketStatus::Settled;
+        let result = move_market_to_inplay(&mut market);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("market not open to allow transition to inplay"));
+    }
+}

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -4,8 +4,9 @@ use crate::context::*;
 use crate::error::CoreError;
 use crate::instructions::market::verify_market_authority;
 use crate::instructions::verify_operator_authority;
+use crate::state::market_account::MarketStatus::*;
 use crate::state::market_account::{
-    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome, MarketStatus::ReadyToClose,
+    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome,
 };
 use crate::state::market_position_account::MarketPosition;
 use crate::state::market_type::verify_market_type;
@@ -385,24 +386,8 @@ pub mod monaco_protocol {
     }
 
     pub fn move_market_to_inplay(ctx: Context<UpdateMarketUnauthorized>) -> Result<()> {
-        let now = current_timestamp();
         let market = &mut ctx.accounts.market;
-
-        // market must have inplay enabled
-        require!(market.inplay_enabled, CoreError::MarketInplayNotEnabled);
-
-        // set it `true` only if it's `false`
-        require!(!market.inplay, CoreError::MarketAlreadyInplay);
-
-        // set it `true` only if now is after event start
-        require!(
-            market.event_start_timestamp <= now,
-            CoreError::MarketEventNotStarted,
-        );
-
-        market.inplay = true;
-
-        Ok(())
+        instructions::market::move_market_to_inplay(market)
     }
 
     pub fn open_market(ctx: Context<UpdateMarket>) -> Result<()> {

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -4,9 +4,8 @@ use crate::context::*;
 use crate::error::CoreError;
 use crate::instructions::market::verify_market_authority;
 use crate::instructions::verify_operator_authority;
-use crate::state::market_account::MarketStatus::*;
 use crate::state::market_account::{
-    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome,
+    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome, MarketStatus::ReadyToClose,
 };
 use crate::state::market_position_account::MarketPosition;
 use crate::state::market_type::verify_market_type;


### PR DESCRIPTION
- Prevent markets from moving to inplay if they are not open
- Move inplay transition instruction away from core lib.rs
- Add market inplay transition unit tests

```
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_failure_market_not_open_settled ... ok
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_failure_not_inplay ... ok
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_not_started ... ok
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_failure_market_not_open_initializing ... ok
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_success ... ok
test instructions::market::move_to_inplay::tests::test_market_move_to_inplay_failure_already_inplay ... ok
```