### PR TITLE
fix: ceil test timestamps at i64::max

### DIFF
--- a/programs/monaco_protocol/src/instructions/clock.rs
+++ b/programs/monaco_protocol/src/instructions/clock.rs
@@ -1,4 +1,6 @@
-pub fn current_timestamp() -> i64 {
+use solana_program::clock::UnixTimestamp;
+
+pub fn current_timestamp() -> UnixTimestamp {
     #[cfg(not(test))]
     {
         use solana_program::clock::Clock;
@@ -11,6 +13,7 @@ pub fn current_timestamp() -> i64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs() as i64
+            .as_secs()
+            .min(UnixTimestamp::MAX as u64) as UnixTimestamp
     }
 }


### PR DESCRIPTION
Test code to retrieve system time has a potentially (though unrealistically) unsafe cast from u64 to i64. The solana library uses i64 to represent a timestamp so we're stuck using that as the target type. 

This change makes it clear that we're returning i64 due to the Solana lib (UnixTimestamp is an alias for i64), and caps the value to `i64::MAX`. 

Realistically the Solana timestamp type will need to be updated before our unit tests failing have issues with this clamp/ceil of the return value. 