### PR TITLE
fix: stake was cast to i64 for check, refactor to prevent loss of data

### DIFF
--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -69,8 +69,10 @@ fn initialize_order(
     );
     require!(data.stake > 0_u64, CoreError::CreationStakeZeroOrLess);
     require!(data.price > 1_f64, CoreError::CreationPriceOneOrLess);
+    let stake_precision_check_result =
+        stake_precision_is_within_range(data.stake, market.decimal_limit)?;
     require!(
-        stake_precision_is_within_range(data.stake, market.decimal_limit),
+        stake_precision_check_result,
         CoreError::CreationStakePrecisionIsTooHigh
     );
     require!(


### PR DESCRIPTION
There is a potentially unsafe cast of `stake` in `stake_precision_is_within_range` from `u64` to `i64`. Refactor to remove the need to down cast to `i64`. 