### PR TITLE
fix: postmatch exposure was cast to u64 in an unsafe way

### DIFF
--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -70,7 +70,16 @@ mod total_exposure_tests {
     }
 
     #[test]
-    fn test_total_exposure_some() {
+    fn test_only_unmatched_exposures() {
+        let mut market_position: MarketPosition = MarketPosition::default();
+        market_position.unmatched_exposures = vec![10, 20, 30];
+        market_position.market_outcome_sums = vec![0, 0, 0];
+
+        assert_eq!(30, market_position.total_exposure());
+    }
+
+    #[test]
+    fn test_only_postmatch_exposures() {
         let mut market_position: MarketPosition = MarketPosition::default();
         market_position.unmatched_exposures = vec![0, 0, 0];
         market_position.market_outcome_sums = vec![20, -10, -10]; // match of 10 @ 3.0
@@ -79,17 +88,26 @@ mod total_exposure_tests {
     }
 
     #[test]
+    fn test_both_exposures() {
+        let mut market_position: MarketPosition = MarketPosition::default();
+        market_position.unmatched_exposures = vec![10, 20, 30];
+        market_position.market_outcome_sums = vec![20, -10, -10]; // match of 10 @ 3.0
+
+        assert_eq!(40, market_position.total_exposure());
+    }
+
+    #[test]
     #[should_panic]
     fn test_overflow() {
         let mut market_position: MarketPosition = MarketPosition::default();
-        let loss = (u64::MAX as i128)
+        let loss_bigger_than_u64 = (u64::MAX as i128)
             .checked_neg()
             .unwrap()
             .checked_sub(1)
             .unwrap();
 
         market_position.unmatched_exposures = vec![0, 0, 0];
-        market_position.market_outcome_sums = vec![0, 0, loss];
+        market_position.market_outcome_sums = vec![0, 0, loss_bigger_than_u64];
 
         market_position.total_exposure();
     }

--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -57,13 +57,11 @@ impl MarketPosition {
 }
 
 #[cfg(test)]
-mod tests {
+mod total_exposure_tests {
     use super::*;
 
-    // Market account tests
-
     #[test]
-    fn test_total_exposure_empty() {
+    fn test_empty() {
         let mut market_position: MarketPosition = MarketPosition::default();
         market_position.unmatched_exposures = vec![0, 0, 0];
         market_position.market_outcome_sums = vec![0, 0, 0];
@@ -74,15 +72,15 @@ mod tests {
     #[test]
     fn test_total_exposure_some() {
         let mut market_position: MarketPosition = MarketPosition::default();
-        market_position.unmatched_exposures = vec![10, 10, 10];
+        market_position.unmatched_exposures = vec![0, 0, 0];
         market_position.market_outcome_sums = vec![20, -10, -10]; // match of 10 @ 3.0
 
-        assert_eq!(20, market_position.total_exposure());
+        assert_eq!(10, market_position.total_exposure());
     }
 
     #[test]
     #[should_panic]
-    fn test_total_exposure_overflow() {
+    fn test_overflow() {
         let mut market_position: MarketPosition = MarketPosition::default();
         let loss = (u64::MAX as i128)
             .checked_neg()

--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -81,12 +81,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_total_exposure_overflow() {
         let mut market_position: MarketPosition = MarketPosition::default();
-        let loss = (u64::MAX as i128).checked_sub(1).unwrap();
+        let loss = (u64::MAX as i128)
+            .checked_neg()
+            .unwrap()
+            .checked_sub(1)
+            .unwrap();
+
         market_position.unmatched_exposures = vec![0, 0, 0];
         market_position.market_outcome_sums = vec![0, 0, loss];
 
-        assert_eq!(0, market_position.total_exposure());
+        market_position.total_exposure();
     }
 }

--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -55,3 +55,38 @@ impl MarketPosition {
             .unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Market account tests
+
+    #[test]
+    fn test_total_exposure_empty() {
+        let mut market_position: MarketPosition = MarketPosition::default();
+        market_position.unmatched_exposures = vec![0, 0, 0];
+        market_position.market_outcome_sums = vec![0, 0, 0];
+
+        assert_eq!(0, market_position.total_exposure());
+    }
+
+    #[test]
+    fn test_total_exposure_some() {
+        let mut market_position: MarketPosition = MarketPosition::default();
+        market_position.unmatched_exposures = vec![10, 10, 10];
+        market_position.market_outcome_sums = vec![20, -10, -10]; // match of 10 @ 3.0
+
+        assert_eq!(20, market_position.total_exposure());
+    }
+
+    #[test]
+    fn test_total_exposure_overflow() {
+        let mut market_position: MarketPosition = MarketPosition::default();
+        let loss = (u64::MAX as i128).checked_sub(1).unwrap();
+        market_position.unmatched_exposures = vec![0, 0, 0];
+        market_position.market_outcome_sums = vec![0, 0, loss];
+
+        assert_eq!(0, market_position.total_exposure());
+    }
+}


### PR DESCRIPTION
There is potential unsafe cast from `i128` to `u64` at line 49 in `total_exposure` method. Auditors suggested to use `u64::try_from` instead.