### PR TITLE
fix: use u32 when creating queues

### DIFF
--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -127,7 +127,7 @@ pub struct MarketMatchingPool {
 }
 
 impl MarketMatchingPool {
-    pub const QUEUE_LENGTH: usize = 100;
+    pub const QUEUE_LENGTH: u32 = 100;
 
     pub const SIZE: usize = DISCRIMINATOR_SIZE +
         PUB_KEY_SIZE + // market
@@ -198,16 +198,16 @@ pub struct Cirque {
 }
 
 impl Cirque {
-    pub const fn size_for(length: usize) -> usize {
+    pub const fn size_for(length: u32) -> usize {
         (U32_SIZE  * 2) + // front and len
-        vec_size(QueueItem::SIZE, length) // items
+        vec_size(QueueItem::SIZE, length as usize) // items
     }
 
-    pub fn new(size: usize) -> Cirque {
+    pub fn new(size: u32) -> Cirque {
         Cirque {
             front: 0,
             len: 0,
-            items: vec![QueueItem::default(); size.min(u32::MAX as usize)],
+            items: vec![QueueItem::default(); size as usize],
         }
     }
 
@@ -566,8 +566,8 @@ mod tests {
 
             assert_eq!(item_to_remove.order, result.unwrap().order);
             assert_eq!(4, queue.len());
-            assert_eq!(i, queue.back() as usize);
-            assert_eq!((i + 1) % queue_size, queue.front as usize);
+            assert_eq!(i, queue.back());
+            assert_eq!((i + 1) % queue_size, queue.front);
             assert_eq!(expected_keys, queue.items);
 
             queue.enqueue(item_to_remove);
@@ -1061,8 +1061,8 @@ mod tests {
         assert_eq!(expected_items, queue.items);
     }
 
-    fn generate_populated_queue(size: usize, enqueued_items: usize) -> Cirque {
-        let mut queue = Cirque::new(size as usize);
+    fn generate_populated_queue(size: u32, enqueued_items: u32) -> Cirque {
+        let mut queue = Cirque::new(size);
         for _ in 0..enqueued_items {
             queue.enqueue(QueueItem::new_unique());
         }

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -207,7 +207,7 @@ impl Cirque {
         Cirque {
             front: 0,
             len: 0,
-            items: vec![QueueItem::default(); size],
+            items: vec![QueueItem::default(); size.min(u32::MAX as usize)],
         }
     }
 

--- a/programs/monaco_protocol/src/state/payments_queue.rs
+++ b/programs/monaco_protocol/src/state/payments_queue.rs
@@ -9,7 +9,7 @@ pub struct MarketPaymentsQueue {
 }
 
 impl MarketPaymentsQueue {
-    pub const QUEUE_LENGTH: usize = 100;
+    pub const QUEUE_LENGTH: u32 = 100;
     pub const SIZE: usize = DISCRIMINATOR_SIZE
         + PUB_KEY_SIZE
         + PaymentQueue::size_for(MarketPaymentsQueue::QUEUE_LENGTH);
@@ -42,16 +42,16 @@ pub struct PaymentQueue {
 }
 
 impl PaymentQueue {
-    pub const fn size_for(length: usize) -> usize {
+    pub const fn size_for(length: u32) -> usize {
         (U32_SIZE * 2) + // front and len
-            vec_size(PaymentInfo::SIZE, length) // items
+            vec_size(PaymentInfo::SIZE, length as usize) // items
     }
 
-    pub fn new(size: usize) -> PaymentQueue {
+    pub fn new(size: u32) -> PaymentQueue {
         PaymentQueue {
             front: 0,
             len: 0,
-            items: vec![PaymentInfo::default(); size.min(u32::MAX as usize)],
+            items: vec![PaymentInfo::default(); size as usize],
         }
     }
 

--- a/programs/monaco_protocol/src/state/payments_queue.rs
+++ b/programs/monaco_protocol/src/state/payments_queue.rs
@@ -51,7 +51,7 @@ impl PaymentQueue {
         PaymentQueue {
             front: 0,
             len: 0,
-            items: vec![PaymentInfo::default(); size],
+            items: vec![PaymentInfo::default(); size.min(u32::MAX as usize)],
         }
     }
 


### PR DESCRIPTION
`usize` to `u32` conversions can be potentially unsafe on 64-bit machines, use `u32` explicitly when creating queues