### PR TITLE
feat: trustless crank v1

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -425,12 +425,6 @@ pub struct SettleOrder<'info> {
     pub purchaser: SystemAccount<'info>,
     #[account(mut, address = order.market @ CoreError::SettlementMarketMismatch)]
     pub market: Box<Account<'info, Market>>,
-
-    // crank operator --------------------------------------------
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -465,12 +459,6 @@ pub struct SettleMarketPosition<'info> {
 
     #[account(address = anchor_spl::token::ID)]
     pub token_program: Program<'info, Token>,
-
-    // crank operator -------------------------------------------
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -496,12 +484,6 @@ pub struct VoidMarketPosition<'info> {
 
     #[account(address = anchor_spl::token::ID)]
     pub token_program: Program<'info, Token>,
-
-    // crank operator -------------------------------------------
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -654,11 +636,6 @@ pub struct SetMarketReadyToClose<'info> {
 pub struct CompleteMarketSettlement<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -742,11 +719,6 @@ pub struct CloseOrder<'info> {
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub purchaser: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -762,11 +734,6 @@ pub struct CloseTrade<'info> {
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub payer: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -782,11 +749,6 @@ pub struct CloseMarketPosition<'info> {
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub purchaser: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -802,11 +764,6 @@ pub struct CloseMarketMatchingPool<'info> {
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub payer: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -824,11 +781,6 @@ pub struct CloseMarketOutcome<'info> {
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub authority: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
 }
 
 #[derive(Accounts)]
@@ -858,12 +810,6 @@ pub struct CloseMarket<'info> {
 
     #[account(mut)]
     pub authority: SystemAccount<'info>,
-
-    #[account(mut)]
-    pub crank_operator: Signer<'info>,
-    #[account(seeds = [b"authorised_operators".as_ref(), b"CRANK".as_ref()], bump)]
-    pub authorised_operators: Account<'info, AuthorisedOperators>,
-
     #[account(address = anchor_spl::token::ID)]
     pub token_program: Program<'info, Token>,
 }

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -46,6 +46,7 @@ pub struct CreateOrder<'info> {
     )]
     pub purchaser_token: Account<'info, TokenAccount>,
 
+    #[account(mut)]
     pub market: Box<Account<'info, Market>>,
     #[account(
         init_if_needed,
@@ -120,6 +121,7 @@ pub struct CreateOrderV2<'info> {
     )]
     pub purchaser_token: Account<'info, TokenAccount>,
 
+    #[account(mut)]
     pub market: Box<Account<'info, Market>>,
     #[account(
         init_if_needed,
@@ -375,6 +377,7 @@ pub struct MatchOrders<'info> {
     )]
     pub market_matching_pool_for: Account<'info, MarketMatchingPool>,
 
+    #[account(mut)]
     pub market: Box<Account<'info, Market>>,
     #[account(
         mut,
@@ -438,7 +441,7 @@ pub struct SettleMarketPosition<'info> {
         associated_token::authority = market_position.purchaser,
     )]
     pub purchaser_token_account: Account<'info, TokenAccount>,
-    #[account(address = market_position.market @ CoreError::SettlementMarketMismatch)]
+    #[account(mut, address = market_position.market @ CoreError::SettlementMarketMismatch)]
     pub market: Account<'info, Market>,
     #[account(
         mut,
@@ -478,7 +481,7 @@ pub struct VoidMarketPosition<'info> {
         associated_token::authority = market_position.purchaser,
     )]
     pub purchaser_token_account: Account<'info, TokenAccount>,
-    #[account(address = market_position.market @ CoreError::VoidMarketMismatch)]
+    #[account(mut, address = market_position.market @ CoreError::VoidMarketMismatch)]
     pub market: Box<Account<'info, Market>>,
     #[account(
         mut,
@@ -735,7 +738,7 @@ pub struct CloseOrder<'info> {
         close = purchaser,
     )]
     pub order: Account<'info, Order>,
-    #[account()]
+    #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub purchaser: SystemAccount<'info>,
@@ -755,7 +758,7 @@ pub struct CloseTrade<'info> {
         close = payer,
     )]
     pub trade: Account<'info, Trade>,
-    #[account()]
+    #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub payer: SystemAccount<'info>,
@@ -775,7 +778,7 @@ pub struct CloseMarketPosition<'info> {
         close = purchaser,
     )]
     pub market_position: Account<'info, MarketPosition>,
-    #[account()]
+    #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub purchaser: SystemAccount<'info>,
@@ -795,7 +798,7 @@ pub struct CloseMarketMatchingPool<'info> {
         close = payer,
     )]
     pub market_matching_pool: Account<'info, MarketMatchingPool>,
-    #[account()]
+    #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
     pub payer: SystemAccount<'info>,
@@ -815,6 +818,7 @@ pub struct CloseMarketOutcome<'info> {
     )]
     pub market_outcome: Account<'info, MarketOutcome>,
     #[account(
+        mut,
         has_one = authority @ CoreError::CloseAccountPurchaserMismatch,
     )]
     pub market: Account<'info, Market>,

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -92,6 +92,14 @@ pub enum CoreError {
     VoidOrderIsVoided,
 
     /*
+    Account counts
+     */
+    #[msg("Some accounts are not yet settled/voided for this market")]
+    MarketUnsettledAccountsCountNonZero,
+    #[msg("Some accounts are not yet closed for this market")]
+    MarketUnclosedAccountsCountNonZero,
+
+    /*
     Authorised Operator
      */
     #[msg("Authorised operator list is full")]

--- a/programs/monaco_protocol/src/instructions/close.rs
+++ b/programs/monaco_protocol/src/instructions/close.rs
@@ -1,0 +1,182 @@
+use anchor_lang::prelude::*;
+
+use crate::error::CoreError;
+use crate::state::market_account::MarketStatus::ReadyToClose;
+use crate::state::market_account::{Market, MarketStatus};
+use crate::state::order_account::Order;
+
+pub fn close_market_child_account(market: &mut Market) -> Result<()> {
+    require!(
+        ReadyToClose.eq(&market.market_status),
+        CoreError::MarketNotReadyToClose
+    );
+    market.decrement_unclosed_accounts_count()
+}
+
+pub fn close_order(market: &mut Market, order: &Order) -> Result<()> {
+    require!(
+        order.is_completed(),
+        CoreError::CloseAccountOrderNotComplete
+    );
+    close_market_child_account(market)
+}
+
+pub fn close_market(
+    market_status: &MarketStatus,
+    payment_queue_len: u32,
+    unclosed_accounts_count: u32,
+) -> Result<()> {
+    require!(
+        ReadyToClose.eq(market_status),
+        CoreError::MarketNotReadyToClose
+    );
+    require!(
+        payment_queue_len == 0,
+        CoreError::CloseAccountMarketPaymentQueueNotEmpty
+    );
+    require!(
+        unclosed_accounts_count == 0,
+        CoreError::MarketUnclosedAccountsCountNonZero
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::market_account::MarketOrderBehaviour;
+    use crate::state::market_account::MarketStatus::Open;
+    use crate::state::order_account::OrderStatus;
+
+    // generic close account validation
+
+    #[test]
+    fn test_validate_close_account() {
+        let market = &mut test_market();
+        market.market_status = ReadyToClose;
+        market.unclosed_accounts_count = 1;
+
+        assert!(close_market_child_account(market).is_ok());
+        assert_eq!(market.unclosed_accounts_count, 0);
+    }
+
+    #[test]
+    fn test_validate_close_account_incorrect_status() {
+        let market = &mut test_market();
+        market.market_status = Open;
+
+        let result = close_market_child_account(market);
+        assert!(result.is_err());
+        assert_eq!(Err(error!(CoreError::MarketNotReadyToClose)), result);
+    }
+
+    // close order validation
+
+    #[test]
+    fn test_close_order() {
+        let market = &mut test_market();
+        market.market_status = ReadyToClose;
+        market.unclosed_accounts_count = 1;
+
+        let order = &mut test_order();
+        order.order_status = OrderStatus::SettledWin;
+
+        assert!(close_order(market, order).is_ok());
+        assert_eq!(market.unclosed_accounts_count, 0);
+    }
+
+    #[test]
+    fn test_close_order_not_completed() {
+        let market = &mut test_market();
+        market.market_status = ReadyToClose;
+        market.unclosed_accounts_count = 1;
+
+        let order = &mut test_order();
+        order.order_status = OrderStatus::Open;
+
+        let result = close_order(market, order);
+        assert!(result.is_err());
+        assert_eq!(Err(error!(CoreError::CloseAccountOrderNotComplete)), result);
+    }
+
+    // close market validation
+
+    #[test]
+    fn test_close_market() {
+        assert!(close_market(&ReadyToClose, 0, 0).is_ok());
+    }
+
+    #[test]
+    fn test_close_market_incorrect_status() {
+        let result = close_market(&Open, 0, 0);
+        assert!(result.is_err());
+        assert_eq!(Err(error!(CoreError::MarketNotReadyToClose)), result);
+    }
+
+    #[test]
+    fn test_close_market_payment_queue_not_empty() {
+        let result = close_market(&ReadyToClose, 1, 0);
+        assert!(result.is_err());
+        assert_eq!(
+            Err(error!(CoreError::CloseAccountMarketPaymentQueueNotEmpty)),
+            result
+        );
+    }
+
+    #[test]
+    fn test_close_market_unclosed_accounts() {
+        let result = close_market(&ReadyToClose, 0, 1);
+        assert!(result.is_err());
+        assert_eq!(
+            Err(error!(CoreError::MarketUnclosedAccountsCountNonZero)),
+            result
+        );
+    }
+
+    fn test_market() -> Market {
+        Market {
+            authority: Default::default(),
+            event_account: Default::default(),
+            mint_account: Default::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: false,
+            inplay: false,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
+            escrow_account_bump: 0,
+            event_start_timestamp: 0,
+        }
+    }
+
+    fn test_order() -> Order {
+        Order {
+            purchaser: Default::default(),
+            market: Default::default(),
+            market_outcome_index: 0,
+            for_outcome: false,
+            order_status: OrderStatus::Open,
+            product: None,
+            stake: 0,
+            voided_stake: 0,
+            expected_price: 0.0,
+            creation_timestamp: 0,
+            delay_expiration_timestamp: 0,
+            stake_unmatched: 0,
+            payout: 0,
+            payer: Default::default(),
+            product_commission_rate: 0.0,
+        }
+    }
+}

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -99,6 +99,10 @@ pub fn initialize_outcome(ctx: Context<InitializeMarketOutcome>, title: String) 
         .market
         .increment_market_outcomes_count()
         .map_err(|_| CoreError::MarketOutcomeInitError)?;
+    ctx.accounts
+        .market
+        .increment_unclosed_accounts_count()
+        .map_err(|_| CoreError::MarketOutcomeInitError)?;
 
     Ok(())
 }

--- a/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_event_start_time.rs
@@ -54,6 +54,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -64,6 +65,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
         let time_in_future = 100;
         let now = 99;
@@ -85,6 +87,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -95,6 +98,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
         let time_in_future = 100;
         let now = 101;
@@ -116,6 +120,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -126,6 +131,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
         let time_in_future = 100;
         let now = 99;

--- a/programs/monaco_protocol/src/instructions/market/update_market_locktime.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_locktime.rs
@@ -53,6 +53,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -63,6 +64,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
         let now = 1575975177;
         let time_in_future = 43041841910;
@@ -84,6 +86,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -94,6 +97,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
         let now = 1575975177;
         let time_in_past = 1418209910;

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -33,6 +33,10 @@ pub fn complete_void(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
         ReadyToVoid.eq(&market.market_status),
         CoreError::VoidMarketNotReadyForVoid
     );
+    require!(
+        market.unsettled_accounts_count == 0_u32,
+        CoreError::MarketUnsettledAccountsCountNonZero,
+    );
     market.market_status = Voided;
     Ok(())
 }
@@ -62,6 +66,10 @@ pub fn complete_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()>
     require!(
         ReadyForSettlement.eq(&market.market_status),
         CoreError::SettlementMarketNotReadyForSettlement
+    );
+    require!(
+        market.unsettled_accounts_count == 0_u32,
+        CoreError::MarketUnsettledAccountsCountNonZero,
     );
     market.market_status = Settled;
     Ok(())
@@ -130,6 +138,8 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
             inplay_enabled: false,
@@ -163,6 +173,8 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
             inplay_enabled: false,
@@ -196,6 +208,8 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
             inplay_enabled: false,
@@ -232,6 +246,8 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
             inplay_enabled: false,
@@ -263,6 +279,8 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
             inplay_enabled: false,
@@ -300,6 +318,8 @@ mod tests {
             inplay: false,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
         };
@@ -333,6 +353,8 @@ mod tests {
             inplay: false,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
         };
@@ -366,6 +388,8 @@ mod tests {
             inplay: false,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 0,
         };

--- a/programs/monaco_protocol/src/instructions/market/update_market_title.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_title.rs
@@ -40,6 +40,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -50,6 +51,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         let result = update_market_title(&mut market, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string());
@@ -69,6 +71,7 @@ mod tests {
             market_lock_timestamp: 0,
             market_settle_timestamp: None,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: false,
@@ -79,6 +82,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         let result = update_market_title(&mut market, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string());

--- a/programs/monaco_protocol/src/instructions/market_position/create_market_position.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/create_market_position.rs
@@ -5,10 +5,15 @@ use crate::state::market_position_account::*;
 
 pub fn create_market_position(
     purchaser: &Signer,
-    market: &Account<Market>,
+    market: &mut Account<Market>,
     market_position: &mut Account<MarketPosition>,
 ) -> Result<()> {
     let market_outcomes_len = usize::from(market.market_outcomes_count);
+
+    // if market position is being initialized, increment market account counts
+    if market_position.purchaser == Pubkey::default() {
+        market.increment_account_counts()?;
+    }
 
     market_position.purchaser = purchaser.key();
     market_position.payer = purchaser.key();

--- a/programs/monaco_protocol/src/instructions/market_position/create_market_position.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/create_market_position.rs
@@ -5,15 +5,10 @@ use crate::state::market_position_account::*;
 
 pub fn create_market_position(
     purchaser: &Signer,
-    market: &mut Account<Market>,
+    market: &Account<Market>,
     market_position: &mut Account<MarketPosition>,
 ) -> Result<()> {
     let market_outcomes_len = usize::from(market.market_outcomes_count);
-
-    // if market position is being initialized, increment market account counts
-    if market_position.purchaser == Pubkey::default() {
-        market.increment_account_counts()?;
-    }
 
     market_position.purchaser = purchaser.key();
     market_position.payer = purchaser.key();

--- a/programs/monaco_protocol/src/instructions/market_position/settle_market_position.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/settle_market_position.rs
@@ -18,7 +18,7 @@ pub fn settle_market_position(ctx: Context<SettleMarketPosition>) -> Result<()> 
         return Ok(());
     }
 
-    let market_account = &ctx.accounts.market;
+    let market_account = &mut ctx.accounts.market;
     // validate the market is settled
     require!(
         market_account.market_winning_outcome_index.is_some(),
@@ -66,6 +66,7 @@ pub fn settle_market_position(ctx: Context<SettleMarketPosition>) -> Result<()> 
         u64::try_from(total_payout).map_err(|_| CoreError::SettlementPaymentCalculation)?;
 
     market_position.paid = true;
+    market_account.decrement_unsettled_accounts_count()?;
 
     transfer::transfer_market_position(&ctx, total_payout_u64)
 }

--- a/programs/monaco_protocol/src/instructions/market_position/void_market_position.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/void_market_position.rs
@@ -13,7 +13,7 @@ pub fn void_market_position(ctx: Context<VoidMarketPosition>) -> Result<()> {
         return Ok(());
     }
 
-    let market_account = &ctx.accounts.market;
+    let market_account = &mut ctx.accounts.market;
     // validate the market is ready to void
     require!(
         market_account.market_status.eq(&MarketStatus::ReadyToVoid),
@@ -23,6 +23,7 @@ pub fn void_market_position(ctx: Context<VoidMarketPosition>) -> Result<()> {
     let total_exposure = market_position.total_exposure();
 
     market_position.paid = true;
+    market_account.decrement_unsettled_accounts_count()?;
 
     transfer::transfer_market_position_void(&ctx, total_exposure)
 }

--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -153,6 +153,7 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
         now,
         ctx.accounts.crank_operator.key(),
     );
+    ctx.accounts.market.increment_unclosed_accounts_count()?;
     initialize_trade(
         &mut ctx.accounts.trade_for,
         &ctx.accounts.order_for,
@@ -162,6 +163,7 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
         now,
         ctx.accounts.crank_operator.key(),
     );
+    ctx.accounts.market.increment_unclosed_accounts_count()?;
 
     Ok(())
 }

--- a/programs/monaco_protocol/src/instructions/mod.rs
+++ b/programs/monaco_protocol/src/instructions/mod.rs
@@ -1,10 +1,12 @@
 pub use account::*;
 pub use clock::*;
+pub use close::*;
 pub use math::*;
 pub use operator::*;
 pub use payment::*;
 pub use transfer::*;
 
+pub(crate) mod close;
 pub(crate) mod market;
 pub(crate) mod market_position;
 pub(crate) mod matching;

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -44,6 +44,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
 
     // if never matched close
     if order.stake == order.voided_stake {
+        ctx.accounts.market.decrement_account_counts()?;
         account::close_account(
             &mut ctx.accounts.order.to_account_info(),
             &mut ctx.accounts.purchaser.to_account_info(),

--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -12,7 +12,7 @@ use crate::state::order_account::*;
 
 pub fn create_order<'info>(
     order: &mut Account<Order>,
-    market: &Account<Market>,
+    market: &mut Account<Market>,
     purchaser: &Signer<'info>,
     purchaser_token_account: &Account<'info, TokenAccount>,
     token_program: &Program<'info, Token>,
@@ -31,6 +31,7 @@ pub fn create_order<'info>(
     // queues are always initialized with default items, so if this queue is new, initialize it
     if matching_pool.orders.size() == 0 {
         market::initialize_market_matching_pool(matching_pool, market, order)?;
+        market.increment_unclosed_accounts_count()?;
     }
 
     matching::update_matching_queue_with_new_order(market, matching_pool, order)?;
@@ -44,6 +45,8 @@ pub fn create_order<'info>(
         token_program,
         payment,
     )?;
+
+    market.increment_account_counts()?;
 
     Ok(())
 }
@@ -247,6 +250,8 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
+            unsettled_accounts_count: 0,
         }
     }
 }

--- a/programs/monaco_protocol/src/instructions/order/create_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/create_order.rs
@@ -25,8 +25,11 @@ pub fn create_order<'info>(
 ) -> Result<()> {
     initialize_order(order, market, purchaser, market_outcome, product, data)?;
 
-    // initialize market position
-    market_position::create_market_position(purchaser, market, market_position)?;
+    // initialize market position if needed
+    if market_position.purchaser == Pubkey::default() {
+        market_position::create_market_position(purchaser, market, market_position)?;
+        market.increment_account_counts()?;
+    }
 
     // queues are always initialized with default items, so if this queue is new, initialize it
     if matching_pool.orders.size() == 0 {

--- a/programs/monaco_protocol/src/instructions/order/settle_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/settle_order.rs
@@ -102,6 +102,7 @@ mod tests {
             market_lock_timestamp: UnixTimestamp::default(),
             market_settle_timestamp: None,
             title: String::from("META"),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: true,
@@ -112,6 +113,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         // then
@@ -150,6 +152,7 @@ mod tests {
             market_lock_timestamp: UnixTimestamp::default(),
             market_settle_timestamp: None,
             title: String::from("META"),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: true,
@@ -160,6 +163,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         // then
@@ -198,6 +202,7 @@ mod tests {
             market_lock_timestamp: UnixTimestamp::default(),
             market_settle_timestamp: None,
             title: String::from("META"),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: true,
@@ -208,6 +213,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         // then
@@ -246,6 +252,7 @@ mod tests {
             market_lock_timestamp: UnixTimestamp::default(),
             market_settle_timestamp: None,
             title: String::from("META"),
+            unsettled_accounts_count: 0,
             market_status: MarketStatus::ReadyForSettlement,
             escrow_account_bump: 0,
             published: true,
@@ -256,6 +263,7 @@ mod tests {
             inplay_order_delay: 0,
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
+            unclosed_accounts_count: 0,
         };
 
         // then

--- a/programs/monaco_protocol/src/instructions/order/void_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/void_order.rs
@@ -4,7 +4,7 @@ use crate::error::CoreError;
 use crate::state::market_account::{Market, MarketStatus};
 use crate::state::order_account::*;
 
-pub fn void_order(order: &mut Account<Order>, market: &Account<Market>) -> Result<()> {
+pub fn void_order(order: &mut Account<Order>, market: &mut Account<Market>) -> Result<()> {
     require!(
         market.market_status.eq(&MarketStatus::ReadyToVoid),
         CoreError::VoidMarketNotReadyForVoid
@@ -17,6 +17,8 @@ pub fn void_order(order: &mut Account<Order>, market: &Account<Market>) -> Resul
     order.order_status = OrderStatus::Voided;
     order.voided_stake = order.stake;
     order.stake_unmatched = 0_u64;
+
+    market.decrement_unsettled_accounts_count()?;
 
     Ok(())
 }

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -5,7 +5,7 @@ use crate::error::CoreError;
 use crate::instructions::market::verify_market_authority;
 use crate::instructions::verify_operator_authority;
 use crate::state::market_account::{
-    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome, MarketStatus::ReadyToClose,
+    Market, MarketMatchingPool, MarketOrderBehaviour, MarketOutcome,
 };
 use crate::state::market_position_account::MarketPosition;
 use crate::state::market_type::verify_market_type;
@@ -104,36 +104,15 @@ pub mod monaco_protocol {
     }
 
     pub fn settle_order(ctx: Context<SettleOrder>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        instructions::order::settle_order(ctx)?;
-
-        Ok(())
+        instructions::order::settle_order(ctx)
     }
 
     pub fn settle_market_position(ctx: Context<SettleMarketPosition>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        instructions::market_position::settle_market_position(ctx)?;
-
-        Ok(())
+        instructions::market_position::settle_market_position(ctx)
     }
 
     pub fn void_market_position(ctx: Context<VoidMarketPosition>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        instructions::market_position::void_market_position(ctx)?;
-
-        Ok(())
+        instructions::market_position::void_market_position(ctx)
     }
 
     pub fn void_order(ctx: Context<VoidOrder>) -> Result<()> {
@@ -433,11 +412,6 @@ pub mod monaco_protocol {
     }
 
     pub fn complete_market_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
         instructions::market::complete_settlement(ctx)
     }
 
@@ -456,11 +430,6 @@ pub mod monaco_protocol {
     }
 
     pub fn complete_market_void(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
         instructions::market::complete_void(ctx)
     }
 
@@ -563,113 +532,32 @@ pub mod monaco_protocol {
      */
 
     pub fn close_order(ctx: Context<CloseOrder>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        require!(
-            ctx.accounts.order.is_completed(),
-            CoreError::CloseAccountOrderNotComplete
-        );
-
-        ctx.accounts.market.decrement_unclosed_accounts_count()?;
-
-        Ok(())
+        instructions::close::close_order(&mut ctx.accounts.market, &ctx.accounts.order)
     }
 
     pub fn close_trade(ctx: Context<CloseTrade>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        ctx.accounts.market.decrement_unclosed_accounts_count()?;
-
-        Ok(())
+        instructions::close::close_market_child_account(&mut ctx.accounts.market)
     }
 
     pub fn close_market_position(ctx: Context<CloseMarketPosition>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        ctx.accounts.market.decrement_unclosed_accounts_count()?;
-
-        Ok(())
+        instructions::close::close_market_child_account(&mut ctx.accounts.market)
     }
 
     pub fn close_market_matching_pool(ctx: Context<CloseMarketMatchingPool>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        ctx.accounts.market.decrement_unclosed_accounts_count()?;
-
-        Ok(())
+        instructions::close::close_market_child_account(&mut ctx.accounts.market)
     }
 
     pub fn close_market_outcome(ctx: Context<CloseMarketOutcome>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
-        )?;
-
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        ctx.accounts.market.decrement_unclosed_accounts_count()?;
-
-        Ok(())
+        instructions::close::close_market_child_account(&mut ctx.accounts.market)
     }
 
     pub fn close_market(ctx: Context<CloseMarket>) -> Result<()> {
-        verify_operator_authority(
-            ctx.accounts.crank_operator.key,
-            &ctx.accounts.authorised_operators,
+        instructions::close::close_market(
+            &ctx.accounts.market.market_status,
+            ctx.accounts.commission_payment_queue.payment_queue.len(),
+            ctx.accounts.market.unclosed_accounts_count,
         )?;
 
-        require!(
-            ReadyToClose.eq(&ctx.accounts.market.market_status),
-            CoreError::MarketNotReadyToClose
-        );
-
-        require!(
-            ctx.accounts.commission_payment_queue.payment_queue.len() == 0,
-            CoreError::CloseAccountMarketPaymentQueueNotEmpty
-        );
-
-        require!(
-            ctx.accounts.market.unclosed_accounts_count == 0,
-            CoreError::MarketUnclosedAccountsCountNonZero
-        );
-
-        instructions::market::close_escrow_token_account(&ctx)?;
-
-        Ok(())
+        instructions::market::close_escrow_token_account(&ctx)
     }
 }

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -40,7 +40,7 @@ pub mod monaco_protocol {
     ) -> Result<()> {
         instructions::order::create_order(
             &mut ctx.accounts.order,
-            &ctx.accounts.market,
+            &mut ctx.accounts.market,
             &ctx.accounts.purchaser,
             &ctx.accounts.purchaser_token,
             &ctx.accounts.token_program,
@@ -60,7 +60,7 @@ pub mod monaco_protocol {
     ) -> Result<()> {
         instructions::order::create_order(
             &mut ctx.accounts.order,
-            &ctx.accounts.market,
+            &mut ctx.accounts.market,
             &ctx.accounts.purchaser,
             &ctx.accounts.purchaser_token,
             &ctx.accounts.token_program,
@@ -137,7 +137,7 @@ pub mod monaco_protocol {
     }
 
     pub fn void_order(ctx: Context<VoidOrder>) -> Result<()> {
-        instructions::order::void_order(&mut ctx.accounts.order, &ctx.accounts.market)
+        instructions::order::void_order(&mut ctx.accounts.order, &mut ctx.accounts.market)
     }
 
     pub fn authorise_admin_operator(
@@ -578,6 +578,8 @@ pub mod monaco_protocol {
             CoreError::CloseAccountOrderNotComplete
         );
 
+        ctx.accounts.market.decrement_unclosed_accounts_count()?;
+
         Ok(())
     }
 
@@ -591,6 +593,8 @@ pub mod monaco_protocol {
             ReadyToClose.eq(&ctx.accounts.market.market_status),
             CoreError::MarketNotReadyToClose
         );
+
+        ctx.accounts.market.decrement_unclosed_accounts_count()?;
 
         Ok(())
     }
@@ -606,6 +610,8 @@ pub mod monaco_protocol {
             CoreError::MarketNotReadyToClose
         );
 
+        ctx.accounts.market.decrement_unclosed_accounts_count()?;
+
         Ok(())
     }
 
@@ -620,6 +626,8 @@ pub mod monaco_protocol {
             CoreError::MarketNotReadyToClose
         );
 
+        ctx.accounts.market.decrement_unclosed_accounts_count()?;
+
         Ok(())
     }
 
@@ -633,6 +641,8 @@ pub mod monaco_protocol {
             ReadyToClose.eq(&ctx.accounts.market.market_status),
             CoreError::MarketNotReadyToClose
         );
+
+        ctx.accounts.market.decrement_unclosed_accounts_count()?;
 
         Ok(())
     }
@@ -651,6 +661,11 @@ pub mod monaco_protocol {
         require!(
             ctx.accounts.commission_payment_queue.payment_queue.len() == 0,
             CoreError::CloseAccountMarketPaymentQueueNotEmpty
+        );
+
+        require!(
+            ctx.accounts.market.unclosed_accounts_count == 0,
+            CoreError::MarketUnclosedAccountsCountNonZero
         );
 
         instructions::market::close_escrow_token_account(&ctx)?;

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -1242,4 +1242,85 @@ mod tests {
         result1.liquidity_to_add = 20;
         assert_eq!(20, queue.items[1].liquidity_to_add);
     }
+
+    // test account count fields
+
+    #[test]
+    fn test_increment_unsettled_accounts_count() {
+        let mut market = test_market();
+
+        let result = market.increment_unsettled_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(1, market.unsettled_accounts_count);
+
+        let result = market.increment_unsettled_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(2, market.unsettled_accounts_count);
+    }
+
+    #[test]
+    fn test_decrement_unsettled_accounts_count() {
+        let mut market = test_market();
+
+        let result = market.increment_unsettled_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(1, market.unsettled_accounts_count);
+
+        let result = market.decrement_unsettled_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(0, market.unsettled_accounts_count);
+    }
+
+    #[test]
+    fn test_increment_unclosed_accounts_count() {
+        let mut market = test_market();
+
+        let result = market.increment_unclosed_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(1, market.unclosed_accounts_count);
+
+        let result = market.increment_unclosed_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(2, market.unclosed_accounts_count);
+    }
+
+    #[test]
+    fn test_decrement_unclosed_accounts_count() {
+        let mut market = test_market();
+
+        let result = market.increment_unclosed_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(1, market.unclosed_accounts_count);
+
+        let result = market.decrement_unclosed_accounts_count();
+        assert!(result.is_ok());
+        assert_eq!(0, market.unclosed_accounts_count);
+    }
+
+    fn test_market() -> Market {
+        Market {
+            authority: Default::default(),
+            event_account: Default::default(),
+            mint_account: Default::default(),
+            market_status: MarketStatus::Initializing,
+            inplay_enabled: false,
+            inplay: false,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
+            escrow_account_bump: 0,
+            event_start_timestamp: 0,
+        }
+    }
 }

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -33,6 +33,9 @@ pub struct Market {
 
     pub title: String,
 
+    pub unsettled_accounts: u32,
+    pub unclosed_accounts: u32,
+
     pub escrow_account_bump: u8,
     pub event_start_timestamp: i64,
 }
@@ -57,7 +60,8 @@ impl Market {
         + U8_SIZE // inplay_order_delay
         + vec_size(CHAR_SIZE, Market::TITLE_MAX_LENGTH) // title
         + U8_SIZE // bump
-        + I64_SIZE; // event_start_timestamp
+        + I64_SIZE // event_start_timestamp
+        + U32_SIZE * 2; // unsettled_accounts + unclosed_accounts
 
     pub fn increment_market_outcomes_count(&mut self) -> Result<u16> {
         self.market_outcomes_count = self

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -71,36 +71,36 @@ impl Market {
         Ok(self.market_outcomes_count)
     }
 
-    pub fn increment_unsettled_accounts_count(&mut self) -> Result<u32> {
+    pub fn increment_unsettled_accounts_count(&mut self) -> Result<()> {
         self.unsettled_accounts_count = self
             .unsettled_accounts_count
             .checked_add(1_u32)
             .ok_or(CoreError::ArithmeticError)?;
-        Ok(self.unsettled_accounts_count)
+        Ok(())
     }
 
-    pub fn decrement_unsettled_accounts_count(&mut self) -> Result<u32> {
+    pub fn decrement_unsettled_accounts_count(&mut self) -> Result<()> {
         self.unsettled_accounts_count = self
             .unsettled_accounts_count
             .checked_sub(1_u32)
             .ok_or(CoreError::ArithmeticError)?;
-        Ok(self.unsettled_accounts_count)
+        Ok(())
     }
 
-    pub fn increment_unclosed_accounts_count(&mut self) -> Result<u32> {
+    pub fn increment_unclosed_accounts_count(&mut self) -> Result<()> {
         self.unclosed_accounts_count = self
             .unclosed_accounts_count
             .checked_add(1_u32)
             .ok_or(CoreError::ArithmeticError)?;
-        Ok(self.unclosed_accounts_count)
+        Ok(())
     }
 
-    pub fn decrement_unclosed_accounts_count(&mut self) -> Result<u32> {
+    pub fn decrement_unclosed_accounts_count(&mut self) -> Result<()> {
         self.unclosed_accounts_count = self
             .unclosed_accounts_count
             .checked_sub(1_u32)
             .ok_or(CoreError::ArithmeticError)?;
-        Ok(self.unclosed_accounts_count)
+        Ok(())
     }
 
     pub fn increment_account_counts(&mut self) -> Result<()> {

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -33,8 +33,8 @@ pub struct Market {
 
     pub title: String,
 
-    pub unsettled_accounts: u32,
-    pub unclosed_accounts: u32,
+    pub unsettled_accounts_count: u32,
+    pub unclosed_accounts_count: u32,
 
     pub escrow_account_bump: u8,
     pub event_start_timestamp: i64,
@@ -69,6 +69,50 @@ impl Market {
             .checked_add(1_u16)
             .ok_or(CoreError::ArithmeticError)?;
         Ok(self.market_outcomes_count)
+    }
+
+    pub fn increment_unsettled_accounts_count(&mut self) -> Result<u32> {
+        self.unsettled_accounts_count = self
+            .unsettled_accounts_count
+            .checked_add(1_u32)
+            .ok_or(CoreError::ArithmeticError)?;
+        Ok(self.unsettled_accounts_count)
+    }
+
+    pub fn decrement_unsettled_accounts_count(&mut self) -> Result<u32> {
+        self.unsettled_accounts_count = self
+            .unsettled_accounts_count
+            .checked_sub(1_u32)
+            .ok_or(CoreError::ArithmeticError)?;
+        Ok(self.unsettled_accounts_count)
+    }
+
+    pub fn increment_unclosed_accounts_count(&mut self) -> Result<u32> {
+        self.unclosed_accounts_count = self
+            .unclosed_accounts_count
+            .checked_add(1_u32)
+            .ok_or(CoreError::ArithmeticError)?;
+        Ok(self.unclosed_accounts_count)
+    }
+
+    pub fn decrement_unclosed_accounts_count(&mut self) -> Result<u32> {
+        self.unclosed_accounts_count = self
+            .unclosed_accounts_count
+            .checked_sub(1_u32)
+            .ok_or(CoreError::ArithmeticError)?;
+        Ok(self.unclosed_accounts_count)
+    }
+
+    pub fn increment_account_counts(&mut self) -> Result<()> {
+        self.increment_unsettled_accounts_count()?;
+        self.increment_unclosed_accounts_count()?;
+        Ok(())
+    }
+
+    pub fn decrement_account_counts(&mut self) -> Result<()> {
+        self.decrement_unsettled_accounts_count()?;
+        self.decrement_unclosed_accounts_count()?;
+        Ok(())
     }
 
     pub fn is_inplay(&self) -> bool {
@@ -387,6 +431,8 @@ mod tests {
             market_lock_order_behaviour: MarketOrderBehaviour::None,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: now + 1000,
         };
@@ -419,6 +465,8 @@ mod tests {
             market_lock_order_behaviour: MarketOrderBehaviour::None,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: now + 1000,
         };
@@ -451,6 +499,8 @@ mod tests {
             market_lock_order_behaviour: MarketOrderBehaviour::None,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: now,
         };
@@ -483,6 +533,8 @@ mod tests {
             market_lock_order_behaviour: MarketOrderBehaviour::None,
             inplay_order_delay: 0,
             title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: now,
         };

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -198,9 +198,6 @@ describe("End to end test of", () => {
               market: market.pk,
               trade: trade,
               payer: monaco.operatorPk,
-              crankOperator: monaco.operatorPk,
-              authorisedOperators:
-                await monaco.findCrankAuthorisedOperatorsPda(),
             })
             .rpc()
             .catch((e) => {
@@ -221,9 +218,6 @@ describe("End to end test of", () => {
               market: market.pk,
               order: order,
               purchaser: purchaser.publicKey,
-              crankOperator: monaco.operatorPk,
-              authorisedOperators:
-                await monaco.findCrankAuthorisedOperatorsPda(),
             })
             .rpc()
             .catch((e) => {
@@ -244,9 +238,6 @@ describe("End to end test of", () => {
               market: market.pk,
               marketPosition: marketPosition,
               purchaser: purchaser.publicKey,
-              crankOperator: monaco.operatorPk,
-              authorisedOperators:
-                await monaco.findCrankAuthorisedOperatorsPda(),
             })
             .rpc()
             .catch((e) => {
@@ -267,9 +258,6 @@ describe("End to end test of", () => {
               market: market.pk,
               marketMatchingPool: marketMatchingPool,
               payer: purchaser.publicKey,
-              crankOperator: monaco.operatorPk,
-              authorisedOperators:
-                await monaco.findCrankAuthorisedOperatorsPda(),
             })
             .rpc()
             .catch((e) => {
@@ -290,9 +278,6 @@ describe("End to end test of", () => {
               market: market.pk,
               marketOutcome: marketOutcome,
               authority: monaco.operatorPk,
-              crankOperator: monaco.operatorPk,
-              authorisedOperators:
-                await monaco.findCrankAuthorisedOperatorsPda(),
             })
             .rpc()
             .catch((e) => {
@@ -308,8 +293,6 @@ describe("End to end test of", () => {
         market: market.pk,
         authority: monaco.operatorPk,
         marketEscrow: market.escrowPk,
-        crankOperator: monaco.operatorPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
         commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()

--- a/tests/market/update_market_status.ts
+++ b/tests/market/update_market_status.ts
@@ -76,8 +76,6 @@ describe("Market: update status", () => {
       .completeMarketSettlement()
       .accounts({
         market: market.pk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -114,8 +112,6 @@ describe("Market: update status", () => {
       .completeMarketSettlement()
       .accounts({
         market: market.pk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -222,8 +218,6 @@ describe("Market: update status", () => {
       .completeMarketSettlement()
       .accounts({
         market: market.pk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc();
 
@@ -284,8 +278,6 @@ describe("Market: update status", () => {
       .completeMarketSettlement()
       .accounts({
         market: market.pk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_market_matching_pool.ts
+++ b/tests/protocol/close_market_matching_pool.ts
@@ -41,8 +41,6 @@ describe("Close market matching pool accounts", () => {
         market: market.pk,
         payer: purchaserA.publicKey,
         marketMatchingPool: matchingPoolPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -87,8 +85,6 @@ describe("Close market matching pool accounts", () => {
         market: market.pk,
         payer: purchaserA.publicKey,
         marketMatchingPool: matchingPoolPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -126,8 +122,6 @@ describe("Close market matching pool accounts", () => {
         market: market.pk,
         payer: purchaserB.publicKey,
         marketMatchingPool: matchingPoolPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -170,8 +164,6 @@ describe("Close market matching pool accounts", () => {
         market: marketB.pk,
         payer: purchaserA.publicKey,
         marketMatchingPool: matchingPoolPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -214,8 +206,6 @@ describe("Close market matching pool accounts", () => {
         market: marketA.pk,
         payer: purchaserA.publicKey,
         marketMatchingPool: matchingPoolPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_market_outcome.ts
+++ b/tests/protocol/close_market_outcome.ts
@@ -38,8 +38,6 @@ describe("Close market outcome accounts", () => {
         market: market.pk,
         authority: marketOperator.publicKey,
         marketOutcome: marketOutcomePk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -75,8 +73,6 @@ describe("Close market outcome accounts", () => {
         market: market.pk,
         authority: marketOperator.publicKey,
         marketOutcome: market.outcomePks[0],
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -108,8 +104,6 @@ describe("Close market outcome accounts", () => {
         market: market.pk,
         authority: monaco.operatorPk,
         marketOutcome: market.outcomePks[0],
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -151,8 +145,6 @@ describe("Close market outcome accounts", () => {
         market: marketB.pk,
         authority: monaco.operatorPk,
         marketOutcome: marketA.outcomePks[0],
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_market_position.ts
+++ b/tests/protocol/close_market_position.ts
@@ -47,8 +47,6 @@ describe("Close market position accounts", () => {
         market: market.pk,
         purchaser: purchaserA.publicKey,
         marketPosition: marketPositionPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -98,8 +96,6 @@ describe("Close market position accounts", () => {
         market: market.pk,
         purchaser: purchaserA.publicKey,
         marketPosition: marketPositionPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -142,8 +138,6 @@ describe("Close market position accounts", () => {
         market: market.pk,
         purchaser: purchaserB.publicKey,
         marketPosition: marketPositionPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -191,8 +185,6 @@ describe("Close market position accounts", () => {
         market: marketB.pk,
         purchaser: purchaserA.publicKey,
         marketPosition: marketPositionPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -50,8 +50,6 @@ describe("Close market accounts (settled)", () => {
         marketEscrow: market.escrowPk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -110,8 +108,6 @@ describe("Close market accounts (settled)", () => {
         marketEscrow: market.escrowPk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -144,8 +140,6 @@ describe("Close market accounts (settled)", () => {
         marketEscrow: market.escrowPk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: monaco.operatorPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -192,8 +186,6 @@ describe("Close market accounts (settled)", () => {
         marketEscrow: marketB.escrowPk,
         commissionPaymentQueue: marketB.paymentsQueuePk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -227,8 +219,6 @@ describe("Close market accounts (settled)", () => {
         marketEscrow: market.escrowPk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -13,7 +13,7 @@ describe("Close market accounts (settled)", () => {
       marketOperator.publicKey,
     );
     const market = await monaco.createMarket(
-      ["A", "B", "C"],
+      ["A", "B"],
       [price],
       marketOperator,
     );
@@ -21,11 +21,19 @@ describe("Close market accounts (settled)", () => {
     const balanceMarketCreated = await monaco.provider.connection.getBalance(
       marketOperator.publicKey,
     );
+    const outcomeARent = await monaco.provider.connection.getBalance(
+      market.outcomePks[0],
+    );
+    const outcomeBRent = await monaco.provider.connection.getBalance(
+      market.outcomePks[0],
+    );
 
     await market.open();
     await market.settle(0);
     await market.completeSettlement();
     await market.readyToClose();
+    await market.closeOutcome(0);
+    await market.closeOutcome(1);
 
     const marketRent = await monaco.provider.connection.getBalance(market.pk);
     const escrowRent = await monaco.provider.connection.getBalance(
@@ -53,7 +61,12 @@ describe("Close market accounts (settled)", () => {
 
     // ensure rent has been returned
     const expectedBalanceAfterMarketClosed =
-      balanceMarketCreated + marketRent + escrowRent + paymentsQueueRent;
+      balanceMarketCreated +
+      marketRent +
+      escrowRent +
+      paymentsQueueRent +
+      outcomeARent +
+      outcomeBRent;
     assert.equal(balanceAfterMarketClosed, expectedBalanceAfterMarketClosed);
 
     await monaco.program.account.market.fetch(market.pk).catch((e) => {
@@ -148,12 +161,12 @@ describe("Close market accounts (settled)", () => {
       marketOperator.publicKey,
     );
     const marketA = await monaco.createMarket(
-      ["A", "B", "C"],
+      ["A", "B"],
       [price],
       marketOperator,
     );
     const marketB = await monaco.createMarket(
-      ["A", "B", "C"],
+      ["A", "B"],
       [price],
       marketOperator,
     );
@@ -162,11 +175,15 @@ describe("Close market accounts (settled)", () => {
     await marketA.settle(0);
     await marketA.completeSettlement();
     await marketA.readyToClose();
+    await marketA.closeOutcome(0);
+    await marketA.closeOutcome(1);
 
     await marketB.open();
     await marketB.settle(0);
     await marketB.completeSettlement();
     await marketB.readyToClose();
+    await marketB.closeOutcome(0);
+    await marketB.closeOutcome(1);
 
     await monaco.program.methods
       .closeMarket()

--- a/tests/protocol/close_market_voided.ts
+++ b/tests/protocol/close_market_voided.ts
@@ -49,8 +49,7 @@ describe("Close market accounts (voided)", () => {
         market: market.pk,
         marketEscrow: market.escrowPk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
+
         commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()
@@ -109,8 +108,7 @@ describe("Close market accounts (voided)", () => {
         market: market.pk,
         marketEscrow: market.escrowPk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
+
         commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()
@@ -143,8 +141,7 @@ describe("Close market accounts (voided)", () => {
         market: market.pk,
         marketEscrow: market.escrowPk,
         authority: monaco.operatorPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
+
         commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()
@@ -191,8 +188,7 @@ describe("Close market accounts (voided)", () => {
         market: marketB.pk,
         marketEscrow: marketB.escrowPk,
         authority: marketOperator.publicKey,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
+
         commissionPaymentQueue: marketB.paymentsQueuePk,
       })
       .rpc()
@@ -221,8 +217,6 @@ describe("Close market accounts (voided)", () => {
       .completeMarketVoid()
       .accounts({
         market: market.pk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/protocol/close_order.ts
+++ b/tests/protocol/close_order.ts
@@ -40,8 +40,6 @@ describe("Close order accounts", () => {
         market: market.pk,
         purchaser: purchaserA.publicKey,
         order: forOrder,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -82,8 +80,6 @@ describe("Close order accounts", () => {
         market: market.pk,
         purchaser: purchaserA.publicKey,
         order: forOrder,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -119,8 +115,6 @@ describe("Close order accounts", () => {
         market: market.pk,
         purchaser: purchaserB.publicKey,
         order: forOrder,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -161,8 +155,6 @@ describe("Close order accounts", () => {
         market: marketB.pk,
         purchaser: purchaserA.publicKey,
         order: forOrder,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -192,8 +184,6 @@ describe("Close order accounts", () => {
         market: market.pk,
         purchaser: purchaser.publicKey,
         order: forOrderPk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));

--- a/tests/protocol/close_trade.ts
+++ b/tests/protocol/close_trade.ts
@@ -53,8 +53,6 @@ describe("Close trade accounts", () => {
         market: market.pk,
         payer: crankOperator.publicKey,
         trade: tradePk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -107,8 +105,6 @@ describe("Close trade accounts", () => {
         market: market.pk,
         payer: crankOperator.publicKey,
         trade: tradeResponse.data.tradePk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -158,8 +154,6 @@ describe("Close trade accounts", () => {
         market: marketB.pk,
         payer: crankOperator.publicKey,
         trade: tradeResponse.data.tradePk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -209,8 +203,6 @@ describe("Close trade accounts", () => {
         market: marketB.pk,
         payer: purchaserA.publicKey,
         trade: tradeResponse.data.tradePk,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -893,10 +893,7 @@ export class MonacoMarket {
   }
 
   async settleOrder(orderPk: PublicKey) {
-    const [order, authorisedOperatorsPk] = await Promise.all([
-      this.monaco.fetchOrder(orderPk),
-      await this.monaco.findCrankAuthorisedOperatorsPda(),
-    ]);
+    const order = await this.monaco.fetchOrder(orderPk);
 
     await this.monaco.program.methods
       .settleOrder()
@@ -904,8 +901,6 @@ export class MonacoMarket {
         order: orderPk,
         market: this.pk,
         purchaser: order.purchaser,
-        crankOperator: this.monaco.operatorPk,
-        authorisedOperators: authorisedOperatorsPk,
       })
       .rpc()
       .catch((e) => {
@@ -991,9 +986,6 @@ export class MonacoMarket {
       .completeMarketSettlement()
       .accounts({
         market: this.pk,
-        crankOperator: this.monaco.operatorPk,
-        authorisedOperators:
-          await this.monaco.findCrankAuthorisedOperatorsPda(),
       })
       .rpc()
       .catch((e) => {
@@ -1007,9 +999,6 @@ export class MonacoMarket {
       .completeMarketVoid()
       .accounts({
         market: this.pk,
-        crankOperator: this.monaco.operatorPk,
-        authorisedOperators:
-          await this.monaco.findCrankAuthorisedOperatorsPda(),
       })
       .rpc()
       .catch((e) => {
@@ -1051,8 +1040,6 @@ export class MonacoMarket {
             outcomeIndex,
           )
         ).data.pda,
-        authorisedOperators: await monaco.findCrankAuthorisedOperatorsPda(),
-        crankOperator: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -1060,8 +1047,6 @@ export class MonacoMarket {
 
   async settleMarketPositionForPurchaser(purchaser: PublicKey) {
     const marketPositionPk = await this.cacheMarketPositionPk(purchaser);
-    const authorisedOperatorsPk =
-      await this.monaco.findCrankAuthorisedOperatorsPda();
     const purchaserTokenPk = await this.cachePurchaserTokenPk(purchaser);
     const protocolCommissionPks = await this.cacheProtocolCommissionPks();
 
@@ -1074,8 +1059,6 @@ export class MonacoMarket {
         marketPosition: marketPositionPk,
         marketEscrow: this.escrowPk,
         commissionPaymentQueue: this.paymentsQueuePk,
-        crankOperator: this.monaco.operatorPk,
-        authorisedOperators: authorisedOperatorsPk,
         protocolConfig: protocolCommissionPks.protocolConfigPk,
       })
       .rpc()
@@ -1120,8 +1103,6 @@ export class MonacoMarket {
 
   async voidMarketPositionForPurchaser(purchaser: PublicKey) {
     const marketPositionPk = await this.cacheMarketPositionPk(purchaser);
-    const authorisedOperatorsPk =
-      await this.monaco.findCrankAuthorisedOperatorsPda();
     const purchaserTokenPk = await this.cachePurchaserTokenPk(purchaser);
 
     await this.monaco.program.methods
@@ -1132,8 +1113,6 @@ export class MonacoMarket {
         purchaserTokenAccount: purchaserTokenPk,
         marketPosition: marketPositionPk,
         marketEscrow: this.escrowPk,
-        crankOperator: this.monaco.operatorPk,
-        authorisedOperators: authorisedOperatorsPk,
       })
       .rpc()
       .catch((e) => {


### PR DESCRIPTION
Enable trustless cranking of the majority of our cranks by maintaining a count of unsettled and unclosed market accounts for use at settlement, voiding or closing.