### PR TITLE
fix: stoping void stake override on repeated cancelation

### DIFF
--- a/programs/monaco_protocol/src/instructions/mod.rs
+++ b/programs/monaco_protocol/src/instructions/mod.rs
@@ -15,4 +15,4 @@ mod clock;
 mod math;
 mod operator;
 mod payment;
-mod transfer;
+pub mod transfer;

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -113,7 +113,7 @@ mod test {
     }
 
     #[test]
-    fn ok_cancle_remaining_unmatched_stake() {
+    fn ok_cancel_remaining_unmatched_stake() {
         let market_outcome_index = 1;
         let matched_price = 2.2_f64;
         let payer_pk = Pubkey::new_unique();

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -1,18 +1,20 @@
 use anchor_lang::prelude::*;
 
-use crate::context::CancelPreplayOrderPostEventStart;
 use crate::error::CoreError;
-use crate::instructions::{market_position, transfer};
-use crate::state::market_account::{MarketOrderBehaviour, MarketStatus};
-use crate::state::order_account::OrderStatus::{Matched, Open};
+use crate::instructions::market_position;
+use crate::state::market_account::{
+    Market, MarketMatchingPool, MarketOrderBehaviour, MarketStatus,
+};
+use crate::state::market_position_account::MarketPosition;
+use crate::state::order_account::Order;
+use crate::state::order_account::OrderStatus;
 
 pub fn cancel_preplay_order_post_event_start(
-    ctx: Context<CancelPreplayOrderPostEventStart>,
-) -> Result<()> {
-    let order = &ctx.accounts.order;
-    let market = &ctx.accounts.market;
-    let market_matching_pool = &mut ctx.accounts.market_matching_pool;
-
+    market: &Market,
+    market_matching_pool: &mut MarketMatchingPool,
+    order: &mut Order,
+    market_position: &mut MarketPosition,
+) -> Result<u64> {
     // market is open + in inplay mode + and cancellation is the intended behaviour
     require!(
         [MarketStatus::Open].contains(&market.market_status),
@@ -26,8 +28,12 @@ pub fn cancel_preplay_order_post_event_start(
 
     // order is (open or matched) + created before market event start
     require!(
-        [Open, Matched].contains(&order.order_status),
+        [OrderStatus::Open, OrderStatus::Matched].contains(&order.order_status),
         CoreError::CancelationOrderStatusInvalid
+    );
+    require!(
+        order.stake_unmatched > 0_u64,
+        CoreError::CancelOrderNotCancellable
     );
     require!(
         order.creation_timestamp < market.event_start_timestamp,
@@ -38,14 +44,224 @@ pub fn cancel_preplay_order_post_event_start(
         market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
-    ctx.accounts.order.void_stake_unmatched();
-
-    let order = &ctx.accounts.order;
+    order.void_stake_unmatched();
 
     // calculate refund
-    let refund =
-        market_position::update_on_order_cancellation(&mut ctx.accounts.market_position, order)?;
-    transfer::order_cancelation_post_event_start_refund(&ctx, refund)?;
+    let refund = market_position::update_on_order_cancellation(market_position, order)?;
 
-    Ok(())
+    Ok(refund)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::state::market_account::Cirque;
+    use crate::state::market_account::MarketStatus;
+    use crate::state::order_account::OrderStatus;
+
+    use super::*;
+
+    #[test]
+    fn error_order_status_invalid() {
+        let market_outcome_index = 1;
+        let matched_price = 2.2_f64;
+        let payer_pk = Pubkey::new_unique();
+
+        let market_pk = Pubkey::new_unique();
+        let market = mock_market();
+
+        let mut order = Order {
+            purchaser: Pubkey::new_unique(),
+            market: market_pk,
+            market_outcome_index,
+            for_outcome: false,
+            order_status: OrderStatus::SettledWin,
+            product: None,
+            product_commission_rate: 0.0,
+            expected_price: 2.4_f64,
+            stake: 100_u64,
+            stake_unmatched: 0_u64,
+            voided_stake: 0_u64,
+            payout: 0_u64,
+            creation_timestamp: 0,
+            delay_expiration_timestamp: 0,
+            payer: payer_pk,
+        };
+
+        let mut market_position = MarketPosition::default();
+        market_position.market_outcome_sums.resize(3, 0_i128);
+        market_position.unmatched_exposures.resize(3, 0_u64);
+        let update_on_order_creation =
+            market_position::update_on_order_creation(&mut market_position, &order);
+        assert!(update_on_order_creation.is_ok());
+        assert_eq!(vec!(0, 140, 0), market_position.unmatched_exposures);
+
+        let mut market_matching_pool =
+            mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
+
+        // when
+        let result = cancel_preplay_order_post_event_start(
+            &market,
+            &mut market_matching_pool,
+            &mut order,
+            &mut market_position,
+        );
+
+        // then
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::CancelationOrderStatusInvalid)
+        );
+    }
+
+    #[test]
+    fn error_stake_unmatched_is_zero() {
+        let market_outcome_index = 1;
+        let matched_price = 2.2_f64;
+        let payer_pk = Pubkey::new_unique();
+
+        let market_pk = Pubkey::new_unique();
+        let market = mock_market();
+
+        let mut order = Order {
+            purchaser: Pubkey::new_unique(),
+            market: market_pk,
+            market_outcome_index,
+            for_outcome: false,
+            order_status: OrderStatus::Open,
+            product: None,
+            product_commission_rate: 0.0,
+            expected_price: 2.4_f64,
+            stake: 100_u64,
+            stake_unmatched: 0_u64,
+            voided_stake: 0_u64,
+            payout: 0_u64,
+            creation_timestamp: 0,
+            delay_expiration_timestamp: 0,
+            payer: payer_pk,
+        };
+
+        let mut market_position = MarketPosition::default();
+        market_position.market_outcome_sums.resize(3, 0_i128);
+        market_position.unmatched_exposures.resize(3, 0_u64);
+        let update_on_order_creation =
+            market_position::update_on_order_creation(&mut market_position, &order);
+        assert!(update_on_order_creation.is_ok());
+        assert_eq!(vec!(0, 140, 0), market_position.unmatched_exposures);
+
+        let mut market_matching_pool =
+            mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
+
+        // when
+        let result = cancel_preplay_order_post_event_start(
+            &market,
+            &mut market_matching_pool,
+            &mut order,
+            &mut market_position,
+        );
+
+        // then
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::CancelOrderNotCancellable)
+        );
+    }
+
+    #[test]
+    fn ok_cancle_remaining_unmatched_stake() {
+        let market_outcome_index = 1;
+        let matched_price = 2.2_f64;
+        let payer_pk = Pubkey::new_unique();
+
+        let market_pk = Pubkey::new_unique();
+        let market = mock_market();
+
+        let mut order = Order {
+            purchaser: Pubkey::new_unique(),
+            market: market_pk,
+            market_outcome_index,
+            for_outcome: false,
+            order_status: OrderStatus::Open,
+            product: None,
+            product_commission_rate: 0.0,
+            expected_price: 2.4_f64,
+            stake: 100_u64,
+            stake_unmatched: 10_u64,
+            voided_stake: 0_u64,
+            payout: 0_u64,
+            creation_timestamp: 0,
+            delay_expiration_timestamp: 0,
+            payer: payer_pk,
+        };
+
+        let mut market_position = MarketPosition::default();
+        market_position.market_outcome_sums.resize(3, 0_i128);
+        market_position.unmatched_exposures.resize(3, 0_u64);
+        let update_on_order_creation =
+            market_position::update_on_order_creation(&mut market_position, &order);
+        assert!(update_on_order_creation.is_ok());
+        assert_eq!(vec!(0, 140, 0), market_position.unmatched_exposures);
+
+        let mut market_matching_pool =
+            mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
+
+        // when
+        let result = cancel_preplay_order_post_event_start(
+            &market,
+            &mut market_matching_pool,
+            &mut order,
+            &mut market_position,
+        );
+
+        // then
+        assert!(result.is_ok());
+        assert_eq!(14, result.unwrap());
+        assert_eq!(10, order.voided_stake);
+    }
+
+    fn mock_market() -> Market {
+        Market {
+            authority: Default::default(),
+            event_account: Default::default(),
+            mint_account: Default::default(),
+            market_status: MarketStatus::Open,
+            inplay_enabled: true,
+            inplay: true,
+            market_type: "".to_string(),
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::CancelUnmatched,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            unsettled_accounts_count: 0,
+            unclosed_accounts_count: 0,
+            escrow_account_bump: 0,
+            event_start_timestamp: 100,
+        }
+    }
+
+    fn mock_market_matching_pool(
+        market_pk: Pubkey,
+        market_outcome_index: u16,
+        price: f64,
+    ) -> MarketMatchingPool {
+        MarketMatchingPool {
+            market: market_pk,
+            market_outcome_index,
+            for_outcome: false,
+            price,
+            liquidity_amount: 0_u64,
+            matched_amount: 0_u64,
+            inplay: false,
+            orders: Cirque::new(1),
+            payer: Pubkey::new_unique(),
+        }
+    }
 }

--- a/programs/monaco_protocol/src/instructions/transfer.rs
+++ b/programs/monaco_protocol/src/instructions/transfer.rs
@@ -3,8 +3,7 @@ use anchor_spl::token;
 use anchor_spl::token::{Token, TokenAccount};
 
 use crate::context::{
-    CancelOrder, CancelPreplayOrderPostEventStart, CreateOrder, MatchOrders, SettleMarketPosition,
-    VoidMarketPosition,
+    CancelOrder, CreateOrder, MatchOrders, SettleMarketPosition, VoidMarketPosition,
 };
 use crate::state::market_account::Market;
 
@@ -42,21 +41,6 @@ pub fn order_cancelation_refund(ctx: &Context<CancelOrder>, amount: u64) -> Resu
     transfer_from_market_escrow(
         &accounts.market_escrow,
         &accounts.purchaser_token_account,
-        &accounts.token_program,
-        &accounts.market,
-        amount,
-    )
-}
-
-pub fn order_cancelation_post_event_start_refund(
-    ctx: &Context<CancelPreplayOrderPostEventStart>,
-    amount: u64,
-) -> Result<()> {
-    let accounts = &ctx.accounts;
-
-    transfer_from_market_escrow(
-        &accounts.market_escrow,
-        &accounts.purchaser_token,
         &accounts.token_program,
         &accounts.market,
         amount,
@@ -128,7 +112,7 @@ pub fn transfer_market_escrow_surplus<'info>(
     )
 }
 
-fn transfer_to_market_escrow<'info>(
+pub fn transfer_to_market_escrow<'info>(
     market_escrow: &Account<'info, TokenAccount>,
     purchaser: &Signer<'info>,
     purchaser_token_account: &Account<'info, TokenAccount>,

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -156,8 +156,6 @@ describe("End to end test of", () => {
     assert.equal(order.stakeUnmatched, 0);
 
     // Close orders due to event start
-    await market.cancelPreplayOrderPostEventStart(prePlayOrder01);
-    await market.cancelPreplayOrderPostEventStart(prePlayOrder02);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder03);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder10);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder11);

--- a/tests/protocol/cancel_preplay_order_post_event_start.ts
+++ b/tests/protocol/cancel_preplay_order_post_event_start.ts
@@ -91,7 +91,9 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
     );
   });
 
-  it("success: matched order", async () => {
+  // -----------------------------------------------------------------------------------------------------
+
+  it("failure: matched order", async () => {
     // Set up Market and related accounts
     const { market, purchaser, orderPk } = await setupUnmatchedOrder(
       monaco,
@@ -112,25 +114,13 @@ describe("Security: Cancel Inplay Order Post Event Start", () => {
     await market.updateMarketEventStartTimeToNow();
     await market.moveMarketToInplay();
 
-    await market.cancelPreplayOrderPostEventStart(orderPk);
-
-    assert.deepEqual(
-      await Promise.all([
-        monaco.getOrder(orderPk),
-        market.getMarketPosition(purchaser),
-        market.getEscrowBalance(),
-        market.getTokenBalance(purchaser),
-      ]),
-      [
-        { stakeUnmatched: 0, stakeVoided: 0, status: { matched: {} } },
-        { matched: [0, 0, 0], unmatched: [0, 0, 0] },
-        0,
-        10000,
-      ],
-    );
+    try {
+      await market.cancelPreplayOrderPostEventStart(orderPk);
+      assert.fail("expected CancelOrderNotCancellable");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+    }
   });
-
-  // -----------------------------------------------------------------------------------------------------
 
   it("failure: market settled", async () => {
     // Create market, purchaser


### PR DESCRIPTION
Issue of data erasure was raised https://github.com/MonacoProtocol/protocol/issues/117.

To address it a new check will be added to see if there is anything to cancel. If not it throws an error.
```
    require!(
        order.stake_unmatched > 0_u64,
        CoreError::CancelOrderNotCancellable
    );
```
Additionally signature of `cancel_preplay_order_post_event_start` method was rewritten to allow unit testing. As a side effect transfer logic had to be moved to the `lib.rs` until we find a way to unit test CPI calls.