### PR TITLE
fix: allow orders created before market lock to be matched 

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -22,7 +22,8 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
 
     let now = current_timestamp();
     require!(
-        ctx.accounts.market.market_lock_timestamp > now,
+        order_for.creation_timestamp <= ctx.accounts.market.market_lock_timestamp
+            && order_against.creation_timestamp <= ctx.accounts.market.market_lock_timestamp,
         CoreError::MarketLocked
     );
 

--- a/tests/order/matching_orders_01.ts
+++ b/tests/order/matching_orders_01.ts
@@ -96,7 +96,7 @@ describe("Order Matching Market State", () => {
   it("matching: orders created before market lock should match after lock", async () => {
     const price = 2.0;
     const now = Math.floor(new Date().getTime() / 1000);
-    const lockTime = now + 3000;
+    const lockTime = now + 10;
 
     const [purchaserA, purchaserB, market] = await Promise.all([
       createWalletWithBalance(monaco.provider),
@@ -115,7 +115,7 @@ describe("Order Matching Market State", () => {
     ]);
 
     // wait for market lock
-    await new Promise((e) => setTimeout(e, 3000));
+    await new Promise((e) => setTimeout(e, 7000));
     await market.match(AforPk, BAgainstPk);
 
     assert.deepEqual(


### PR DESCRIPTION
Currently if the market has locked, any matches for orders created before lock will throw an error when cranking matches. With this change, any order created before market lock time should be matched.