### PR TITLE
feat: emit event capturing basics of a trade

### DIFF
--- a/programs/monaco_protocol/src/events/mod.rs
+++ b/programs/monaco_protocol/src/events/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod trade;

--- a/programs/monaco_protocol/src/events/trade.rs
+++ b/programs/monaco_protocol/src/events/trade.rs
@@ -1,0 +1,8 @@
+use anchor_lang::prelude::*;
+
+#[event]
+pub struct TradeEvent {
+    pub amount: u64,
+    pub price: f64,
+    pub market: Pubkey,
+}

--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::context::MatchOrders;
 use crate::error::CoreError;
+use crate::events::trade::TradeEvent;
 use crate::instructions::market_position::update_product_commission_contributions;
 use crate::instructions::matching::create_trade::initialize_trade;
 use crate::instructions::{
@@ -165,6 +166,12 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
         ctx.accounts.crank_operator.key(),
     );
     ctx.accounts.market.increment_unclosed_accounts_count()?;
+
+    emit!(TradeEvent {
+        amount: stake_matched,
+        price: selected_price,
+        market: ctx.accounts.market.key(),
+    });
 
     Ok(())
 }

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -14,6 +14,7 @@ use crate::state::trade_account::Trade;
 
 pub mod context;
 pub mod error;
+pub mod events;
 pub mod instructions;
 pub mod state;
 


### PR DESCRIPTION
This emits an event when a trade (pair) is created, capturing the amount, price, and market pk of the trade. This occurs during the `matchOrders` instruction. 

The intention is to make this data (cheaply) available to analytics tools such as Dune. 

On e.g., Dune, example data that is outputted could be decoded as follows:
```
select 
bytearray_to_bigint(bytearray_reverse(bytearray_substring(from_base64('vdt/007mYe4ALTEBAAAAAAAAAAAAAABAQnyrqOfbyTtv63oJAcHyZaE71Kr3jXhScLqcVV+Gpd0='), 9, 8))) as amount,
from_ieee754_64(bytearray_reverse(bytearray_substring(from_base64('vdt/007mYe4ALTEBAAAAAAAAAAAAAABAQnyrqOfbyTtv63oJAcHyZaE71Kr3jXhScLqcVV+Gpd0='), 17, 8))) as price,
to_base58(bytearray_substring(from_base64('vdt/007mYe4ALTEBAAAAAAAAAAAAAABAQnyrqOfbyTtv63oJAcHyZaE71Kr3jXhScLqcVV+Gpd0='), 25, 32)) as market;
```

The base64 string will be available in the `call_log_messages` data. 