### PR TITLE
fix: enable price ladder changes in client and scripts

### DIFF
--- a/admin/client.ts
+++ b/admin/client.ts
@@ -33,6 +33,7 @@ import {
   printMarketType,
   printMarketTypeByName,
 } from "./market_types";
+import { createPriceLadder } from "./price_ladders";
 
 if (process.argv.length < 3) {
   printUsageAndExit();
@@ -46,6 +47,9 @@ const script = process.argv[2];
 switch (script) {
   case "getAll":
     getAll();
+    break;
+  case "createPriceLadder":
+    createPriceLadder();
     break;
   case "createMarketType":
     createMarketType();

--- a/admin/create_market.ts
+++ b/admin/create_market.ts
@@ -1,12 +1,12 @@
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { Program } from "@coral-xyz/anchor";
-import {
-  createMarketWithOutcomesAndPriceLadder as npmCreateMarket,
-  DEFAULT_PRICE_LADDER,
-} from "../npm-admin-client/src/";
+import { createMarketWithOutcomesAndPriceLadder as npmCreateMarket } from "../npm-admin-client/src/";
 import { getProtocolProgram } from "./util";
 import { Markets, MarketStatusFilter } from "../npm-client";
 
+/**
+ * Example create market script - parameters used for market creation might be need to replaced/created before use
+ */
 export async function create_market() {
   const protocolProgram = await getProtocolProgram();
 
@@ -18,14 +18,14 @@ export async function create_market() {
   const createMarketResponse = await npmCreateMarket(
     protocolProgram as Program,
     "Aduana Stars-Bechem United",
-    "EventResultWinner",
+    "TEST",
     "",
     "",
     marketToken,
     1924254038,
     eventAccountKeyPair.publicKey,
     ["Aduana Stars", "Draw", "Bechem United"],
-    DEFAULT_PRICE_LADDER,
+    new PublicKey("94VCY4rWi3nvyNPHnsRV65n3JZxiPSvXbxfvJydYw9uA"),
     {
       batchSize: 20,
     },

--- a/admin/create_order.ts
+++ b/admin/create_order.ts
@@ -1,6 +1,7 @@
 import { createOrderUiStake } from "../npm-client/src/create_order";
 import { PublicKey } from "@solana/web3.js";
 import { getProtocolProgram } from "./util";
+import { findMarketOutcomePda } from "../npm-admin-client";
 
 // yarn run create_order <MARKET_ID> <OUTCOME_INDEX> <FOR (true|false)> <PRICE> <STAKE>
 // or tsc; ANCHOR_WALLET=~/.config/solana/id.json yarn ts-node client.ts create_order <MARKET_ID> <OUTCOME_INDEX> <FOR (true|false)> <PRICE> <STAKE>
@@ -21,6 +22,12 @@ export async function create_order() {
 
   const protocolProgram = await getProtocolProgram();
 
+  const outcome = await protocolProgram.account.marketOutcome.fetch(
+    (
+      await findMarketOutcomePda(protocolProgram, marketPk, marketOutcomeIndex)
+    ).data.pda,
+  );
+
   const result = await createOrderUiStake(
     protocolProgram,
     marketPk,
@@ -28,6 +35,7 @@ export async function create_order() {
     forOutcome,
     price,
     stake,
+    outcome.prices,
   );
   console.log(JSON.stringify(result, null, 2));
 }

--- a/npm-admin-client/docs/endpoints/market_create.md
+++ b/npm-admin-client/docs/endpoints/market_create.md
@@ -28,7 +28,7 @@ For the given parameters:
 *   `marketLockTimestamp` **EpochTimeStamp** {EpochTimeStamp} timestamp in seconds representing when the market can no longer accept orders
 *   `eventAccountPk` **PublicKey** {PublicKey} publicKey of the event the market is associated with
 *   `outcomes` **[Array][8]<[string][7]>** {string\[]} list of possible outcomes for the market
-*   `priceLadder` **[Array][8]<[number][9]>** {number\[]} array of price points to add to the outcome
+*   `priceLadder` **([Array][8]<[number][9]> | PublicKey)?** {number\[]} array of price points to add to the outcome, or the public key of a price ladder account (Optional - no price ladder will result in the protocol default being used for the market)
 *   `options` **{existingMarketPk: PublicKey?, existingMarket: MarketAccount?, eventStartTimestamp: EpochTimeStamp?, inplayEnabled: [boolean][10]?, inplayOrderDelay: [number][9]?, eventStartOrderBehaviour: MarketOrderBehaviour?, marketLockOrderBehaviour: MarketOrderBehaviour?, batchSize: [number][9]?}?** {object} optional parameters:  <ul>
         <li> existingMarketPk - publicKey of the market to recreate, if any (defaults to null)</li>
         <li> existingMarket - market account for existingMarketPk, will be fetched if not provided</li>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format": "prettier --write \"**/*.{ts,js}\"",
     "prepare": "husky install",
     "getAll": "ts-node admin/client.ts getAll",
+    "createPriceLadder": "ts-node admin/client.ts createPriceLadder",
     "createMarketType": "ts-node admin/client.ts createMarketType",
     "printAllMarketTypes": "ts-node admin/client.ts printAllMarketTypes",
     "printMarketType": "ts-node admin/client.ts printMarketType",


### PR DESCRIPTION
Missed some small bits for the new price ladder functionality
* add admin script to help create/manage the new `PriceLadder` accounts
* update `createMarketWithOutcomesAndPriceLadder` client function to allow price ladder account public keys to be passed in
* update the example admin script for creating markets to use a price ladder account address, not an array of prices. 