### PR TITLE
refactor: trade creation method update

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/create_trade.rs
+++ b/programs/monaco_protocol/src/instructions/matching/create_trade.rs
@@ -1,23 +1,26 @@
 use anchor_lang::prelude::*;
 
-use crate::state::order_account::Order;
 use crate::state::trade_account::Trade;
 
-pub fn initialize_trade(
-    trade: &mut Account<Trade>,
-    order: &Account<Order>,
-    opposite_trade: &Account<Trade>,
+pub fn create_trade(
+    trade: &mut Trade,
+    purchaser_pk: &Pubkey,
+    market_pk: &Pubkey,
+    order_pk: &Pubkey,
+    opposite_trade_pk: &Pubkey,
+    outcome_index: u16,
+    for_outcome: bool,
     stake: u64,
     price: f64,
     creation_timestamp: i64,
     payer: Pubkey,
 ) {
-    trade.purchaser = order.purchaser.key();
-    trade.market = order.market.key();
-    trade.order = order.key();
-    trade.opposite_trade = opposite_trade.key();
-    trade.for_outcome = order.for_outcome;
-    trade.market_outcome_index = order.market_outcome_index;
+    trade.purchaser = *purchaser_pk;
+    trade.market = *market_pk;
+    trade.order = *order_pk;
+    trade.opposite_trade = *opposite_trade_pk;
+    trade.for_outcome = for_outcome;
+    trade.market_outcome_index = outcome_index;
     trade.stake = stake;
     trade.price = price;
     trade.creation_timestamp = creation_timestamp;

--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -4,7 +4,7 @@ use crate::context::MatchOrders;
 use crate::error::CoreError;
 use crate::events::trade::TradeEvent;
 use crate::instructions::market_position::update_product_commission_contributions;
-use crate::instructions::matching::create_trade::initialize_trade;
+use crate::instructions::matching::create_trade::create_trade;
 use crate::instructions::{
     calculate_risk_from_stake, current_timestamp, matching, order, transfer,
 };
@@ -146,20 +146,28 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
 
     // 5. Initialize the trade accounts
     let now = current_timestamp();
-    initialize_trade(
+    create_trade(
         &mut ctx.accounts.trade_against,
-        &ctx.accounts.order_against,
-        &ctx.accounts.trade_for,
+        &ctx.accounts.order_against.purchaser,
+        &ctx.accounts.order_against.market,
+        &ctx.accounts.order_against.key(),
+        &ctx.accounts.trade_for.key(),
+        ctx.accounts.order_against.market_outcome_index,
+        ctx.accounts.order_against.for_outcome,
         stake_matched,
         selected_price,
         now,
         ctx.accounts.crank_operator.key(),
     );
     ctx.accounts.market.increment_unclosed_accounts_count()?;
-    initialize_trade(
+    create_trade(
         &mut ctx.accounts.trade_for,
-        &ctx.accounts.order_for,
-        &ctx.accounts.trade_against,
+        &ctx.accounts.order_for.purchaser,
+        &ctx.accounts.order_for.market,
+        &ctx.accounts.order_for.key(),
+        &ctx.accounts.trade_against.key(),
+        ctx.accounts.order_for.market_outcome_index,
+        ctx.accounts.order_for.for_outcome,
         stake_matched,
         selected_price,
         now,


### PR DESCRIPTION
We have agreed to move away from passing Anchor's wrapper types that are hard to mock for testing.
Additionally changing name of the method to `create_trade` from `initialize_(...)` since we use that more often.