### PR TITLE
feat: introducing market matching queue account

### DIFF
--- a/npm-admin-client/docs/endpoints/market_helpers.md
+++ b/npm-admin-client/docs/endpoints/market_helpers.md
@@ -14,18 +14,21 @@
 *   [findEscrowPda][10]
     *   [Parameters][11]
     *   [Examples][12]
-*   [findCommissionPaymentsQueuePda][13]
+*   [findMarketMatchingQueuePda][13]
     *   [Parameters][14]
     *   [Examples][15]
-*   [MarketOutcomes][16]
+*   [findCommissionPaymentsQueuePda][16]
     *   [Parameters][17]
     *   [Examples][18]
-*   [getMarketOutcomesByMarket][19]
+*   [MarketOutcomes][19]
     *   [Parameters][20]
     *   [Examples][21]
-*   [getMarketOutcomeTitlesByMarket][22]
+*   [getMarketOutcomesByMarket][22]
     *   [Parameters][23]
     *   [Examples][24]
+*   [getMarketOutcomeTitlesByMarket][25]
+    *   [Parameters][26]
+    *   [Examples][27]
 
 ## findMarketPda
 
@@ -36,10 +39,10 @@ For the provided event publicKey, market type and mint publicKey return a Progra
 *   `program` **Program** {program} anchor program initialized by the consuming client
 *   `eventPk` **PublicKey** {PublicKey} publicKey of an event
 *   `marketTypePk` **PublicKey** {PublicKey} publicKey of the market type
-*   `marketTypeDiscriminator` **[string][25]** {string} discriminator of the market type
-*   `marketTypeValue` **[string][25]** {string} value of the market type
+*   `marketTypeDiscriminator` **[string][28]** {string} discriminator of the market type
+*   `marketTypeValue` **[string][28]** {string} value of the market type
 *   `mintPk` **PublicKey** {PublicKey} publicKey of the currency token
-*   `version` **[number][26]?** {number} (Optional) version of the market, defaults to 0
+*   `version` **[number][29]?** {number} (Optional) version of the market, defaults to 0
 
 ### Examples
 
@@ -107,6 +110,24 @@ const escrowPda = await findEscrowPda(program, marketPK)
 ```
 
 Returns **FindPdaResponse** PDA of the escrow account
+
+## findMarketMatchingQueuePda
+
+For the provided market publicKey, return the PDA (publicKey) of the market matching-queue account.
+
+### Parameters
+
+*   `program` **Program** {program} anchor program initialized by the consuming client
+*   `marketPk` **PublicKey** {PublicKey} publicKey of a market
+
+### Examples
+
+```javascript
+const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+const marketMatchingQueuePk = await findMarketMatchingQueuePda(program, marketPK)
+```
+
+Returns **FindPdaResponse** PDA of the market matching-queue account
 
 ## findCommissionPaymentsQueuePda
 
@@ -210,30 +231,36 @@ Returns **MarketOutcomeTitlesResponse** fetched market outcome titles - ordered 
 
 [12]: #examples-3
 
-[13]: #findcommissionpaymentsqueuepda
+[13]: #findmarketmatchingqueuepda
 
 [14]: #parameters-4
 
 [15]: #examples-4
 
-[16]: #marketoutcomes
+[16]: #findcommissionpaymentsqueuepda
 
 [17]: #parameters-5
 
 [18]: #examples-5
 
-[19]: #getmarketoutcomesbymarket
+[19]: #marketoutcomes
 
 [20]: #parameters-6
 
 [21]: #examples-6
 
-[22]: #getmarketoutcometitlesbymarket
+[22]: #getmarketoutcomesbymarket
 
 [23]: #parameters-7
 
 [24]: #examples-7
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[25]: #getmarketoutcometitlesbymarket
 
-[26]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[26]: #parameters-8
+
+[27]: #examples-8
+
+[28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[29]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number

--- a/npm-admin-client/src/market_create.ts
+++ b/npm-admin-client/src/market_create.ts
@@ -18,6 +18,7 @@ import {
   getMarket,
   getMintInfo,
   findEscrowPda,
+  findMarketMatchingQueuePda,
   findCommissionPaymentsQueuePda,
 } from "./market_helpers";
 import { initialiseOutcomes } from "./market_outcome";
@@ -262,13 +263,19 @@ export async function createMarket(
     )
   ).data.pda;
 
-  const [escrowPda, authorisedOperators, mintInfo, paymentsQueuePda] =
-    await Promise.all([
-      findEscrowPda(program, marketPda),
-      findAuthorisedOperatorsAccountPda(program, Operator.MARKET),
-      getMintInfo(program, marketTokenPk),
-      findCommissionPaymentsQueuePda(program, marketPda),
-    ]);
+  const [
+    escrowPda,
+    authorisedOperators,
+    mintInfo,
+    matchingQueuePda,
+    paymentsQueuePda,
+  ] = await Promise.all([
+    findEscrowPda(program, marketPda),
+    findAuthorisedOperatorsAccountPda(program, Operator.MARKET),
+    getMintInfo(program, marketTokenPk),
+    findMarketMatchingQueuePda(program, marketPda),
+    findCommissionPaymentsQueuePda(program, marketPda),
+  ]);
 
   try {
     const tnxId = await program.methods
@@ -298,6 +305,7 @@ export async function createMarket(
         rent: web3.SYSVAR_RENT_PUBKEY,
         authorisedOperators: authorisedOperators.data.pda,
         marketOperator: provider.wallet.publicKey,
+        matchingQueue: matchingQueuePda.data.pda,
         commissionPaymentQueue: paymentsQueuePda.data.pda,
       })
       .rpc();

--- a/npm-admin-client/src/market_helpers.ts
+++ b/npm-admin-client/src/market_helpers.ts
@@ -165,6 +165,39 @@ export async function findEscrowPda(
 }
 
 /**
+ * For the provided market publicKey, return the PDA (publicKey) of the market matching-queue account.
+ *
+ * @param program {program} anchor program initialized by the consuming client
+ * @param marketPk {PublicKey} publicKey of a market
+ * @returns {FindPdaResponse} PDA of the market matching-queue account
+ *
+ * @example
+ *
+ * const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+ * const marketMatchingQueuePk = await findMarketMatchingQueuePda(program, marketPK)
+ */
+export async function findMarketMatchingQueuePda(
+  program: Program,
+  marketPk: PublicKey,
+): Promise<ClientResponse<FindPdaResponse>> {
+  const response = new ResponseFactory({} as FindPdaResponse);
+
+  try {
+    const [pda, _] = PublicKey.findProgramAddressSync(
+      [Buffer.from("matching"), marketPk.toBuffer()],
+      program.programId,
+    );
+
+    response.addResponseData({
+      pda: pda,
+    });
+  } catch (e) {
+    response.addError(e);
+  }
+  return response.body;
+}
+
+/**
  * For the provided market publicKey, return the commission payments queue account PDA (publicKey) for that market.
  *
  * @param program {program} anchor program initialized by the consuming client

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -1,5 +1,6 @@
 use crate::error::CoreError;
 use crate::state::market_matching_pool_account::MarketMatchingPool;
+use crate::state::market_matching_queue_account::MarketMatchingQueue;
 use crate::state::market_outcome_account::MarketOutcome;
 use crate::{AuthorisedOperators, Market, MarketPosition, Order, OrderData, Trade};
 use anchor_lang::prelude::*;
@@ -569,6 +570,17 @@ pub struct CreateMarket<'info> {
     #[account(
         init,
         seeds = [
+            b"matching".as_ref(),
+            market.key().as_ref(),
+        ],
+        bump,
+        payer = market_operator,
+        space = MarketMatchingQueue::SIZE
+    )]
+    pub matching_queue: Box<Account<'info, MarketMatchingQueue>>,
+    #[account(
+        init,
+        seeds = [
             b"commission_payments".as_ref(),
             market.key().as_ref(),
         ],
@@ -902,6 +914,14 @@ pub struct CloseMarket<'info> {
         bump,
     )]
     pub market_escrow: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        has_one = market @ CoreError::CloseAccountMarketMismatch,
+        seeds = [b"matching".as_ref(), market.key().as_ref()],
+        bump,
+        close = authority,
+    )]
+    pub matching_queue: Account<'info, MarketMatchingQueue>,
     #[account(
         mut,
         has_one = market @ CoreError::CloseAccountMarketMismatch,

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -7,6 +7,7 @@ use crate::instructions::current_timestamp;
 use crate::monaco_protocol::PRICE_SCALE;
 use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
 use crate::state::market_matching_pool_account::{Cirque, MarketMatchingPool};
+use crate::state::market_matching_queue_account::{MarketMatchingQueue, MatchingQueue};
 use crate::state::market_outcome_account::MarketOutcome;
 use crate::state::order_account::Order;
 use crate::state::payments_queue::{MarketPaymentsQueue, PaymentQueue};
@@ -135,6 +136,8 @@ pub fn create(
         false
     };
 
+    intialize_matching_queue(&mut ctx.accounts.matching_queue, &ctx.accounts.market.key())?;
+
     intialize_commission_payments_queue(
         &mut ctx.accounts.commission_payment_queue,
         &ctx.accounts.market.key(),
@@ -225,6 +228,15 @@ pub fn add_prices_to_market_outcome(
         CoreError::MarketPriceListIsFull
     );
 
+    Ok(())
+}
+
+fn intialize_matching_queue(
+    matching_queue: &mut MarketMatchingQueue,
+    market: &Pubkey,
+) -> Result<()> {
+    matching_queue.market = *market;
+    matching_queue.matches = MatchingQueue::new(MarketMatchingQueue::QUEUE_LENGTH);
     Ok(())
 }
 

--- a/programs/monaco_protocol/src/state/market_matching_queue_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_queue_account.rs
@@ -1,0 +1,235 @@
+use crate::state::type_size::*;
+use anchor_lang::prelude::*;
+
+use std::string::ToString;
+
+#[account]
+pub struct MarketMatchingQueue {
+    pub market: Pubkey,
+    pub matches: MatchingQueue,
+}
+
+impl MarketMatchingQueue {
+    pub const QUEUE_LENGTH: usize = 80;
+
+    pub const SIZE: usize = DISCRIMINATOR_SIZE +
+        PUB_KEY_SIZE + // market
+        MatchingQueue::size_for(MarketMatchingQueue::QUEUE_LENGTH); //matches
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone)]
+pub struct MatchingQueue {
+    front: u32,
+    len: u32,
+    items: Vec<OrderMatched>,
+}
+
+impl MatchingQueue {
+    pub const fn size_for(length: usize) -> usize {
+        (U32_SIZE  * 2) + // front and len
+        vec_size(OrderMatched::SIZE, length) // items
+    }
+
+    pub fn new(size: usize) -> MatchingQueue {
+        MatchingQueue {
+            front: 0,
+            len: 0,
+            items: vec![OrderMatched::default(); size],
+        }
+    }
+
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    pub fn size(&self) -> u32 {
+        self.items.len() as u32
+    }
+
+    fn back(&self) -> u32 {
+        // #[soteria(ignore)] 0 <= front < size() AND 0 <= len < size() AND size() == QUEUE_LENGTH << u32::MAX
+        (self.front + self.len) % self.size()
+    }
+
+    pub fn peek(&mut self) -> Option<&mut OrderMatched> {
+        if self.len == 0 {
+            None
+        } else {
+            Some(&mut self.items[self.front as usize])
+        }
+    }
+
+    pub fn enqueue(&mut self, item: OrderMatched) -> Option<u32> {
+        if self.len == self.size() {
+            None
+        } else {
+            let old_back = self.back();
+            // #[soteria(ignore)] no overflows due to "if" check
+            self.len += 1;
+            self.items[old_back as usize] = item;
+            Some(old_back)
+        }
+    }
+
+    pub fn dequeue(&mut self) -> Option<&mut OrderMatched> {
+        if self.len == 0 {
+            None
+        } else {
+            let old_front = self.front;
+            self.front = (old_front + 1) % self.size();
+            // #[soteria(ignore)] no underflows due to "if" check
+            self.len -= 1;
+            Some(&mut self.items[old_front as usize])
+        }
+    }
+
+    pub fn to_vec(&self) -> Vec<OrderMatched> {
+        let mut clone = Vec::with_capacity(self.len() as usize);
+        for i in 0..self.len() as usize {
+            let index = (self.front as usize + i) % (self.size() as usize);
+            clone.push(self.items[index]);
+        }
+        clone
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, Default)]
+pub struct OrderMatched {
+    pub pk: Pubkey,
+    pub purchaser: Pubkey,
+
+    pub for_outcome: bool,
+    pub outcome_index: u16,
+    pub price: f64,
+    pub stake: u64,
+}
+
+impl OrderMatched {
+    pub const SIZE: usize =
+        BOOL_SIZE + U16_SIZE + F64_SIZE + U64_SIZE + PUB_KEY_SIZE + PUB_KEY_SIZE;
+}
+
+impl PartialEq for OrderMatched {
+    fn eq(&self, other: &Self) -> bool {
+        self.pk.eq(&other.pk)
+    }
+}
+
+impl Eq for OrderMatched {}
+
+#[cfg(test)]
+mod tests_matching_queue {
+    use super::*;
+
+    #[test]
+    fn enqueue_empty_queue() {
+        let mut queue = MatchingQueue::new(10);
+        assert_eq!(0, queue.len());
+
+        let result = queue.enqueue(order_match());
+        assert!(result.is_some());
+        assert_eq!(0, result.unwrap());
+        assert_eq!(1, queue.len());
+    }
+
+    #[test]
+    fn enqueue_some_queue() {
+        let mut queue = MatchingQueue::new(10);
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        assert_eq!(2, queue.len());
+
+        let result = queue.enqueue(order_match());
+        assert!(result.is_some());
+        assert_eq!(2, result.unwrap());
+        assert_eq!(3, queue.len());
+    }
+
+    #[test]
+    fn enqueue_full_queue() {
+        let mut queue = MatchingQueue::new(10);
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        assert_eq!(10, queue.len());
+
+        let result = queue.enqueue(order_match());
+        assert!(result.is_none());
+        assert_eq!(10, queue.len());
+    }
+
+    #[test]
+    fn dequeue_empty_queue() {
+        let mut queue = MatchingQueue::new(10);
+        assert_eq!(0, queue.len());
+
+        let result = queue.dequeue();
+        assert!(result.is_none());
+        assert_eq!(0, queue.len());
+    }
+
+    #[test]
+    fn dequeue_full_queue() {
+        let mut queue = MatchingQueue::new(10);
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        assert_eq!(3, queue.len());
+
+        let result = queue.dequeue();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn peek_empty_queue() {
+        let mut queue = MatchingQueue::new(10);
+        assert_eq!(0, queue.len());
+
+        let result = queue.peek();
+        assert!(result.is_none());
+        assert_eq!(0, queue.len());
+    }
+
+    #[test]
+    fn peek_full_queue() {
+        let mut queue = MatchingQueue::new(10);
+        let item = order_match();
+        queue.enqueue(item);
+        assert_eq!(1, queue.len());
+
+        let result = queue.peek();
+        assert!(result.is_some());
+        assert_eq!(item, *result.unwrap());
+        assert_eq!(1, queue.len());
+    }
+
+    #[test]
+    fn peek_edit_in_place() {
+        let mut queue = MatchingQueue::new(10);
+        queue.enqueue(order_match());
+        queue.enqueue(order_match());
+        assert_eq!(2, queue.len());
+
+        let result0 = queue.peek().unwrap();
+        result0.stake = 10;
+        assert_eq!(10, queue.items[0].stake);
+    }
+
+    fn order_match() -> OrderMatched {
+        OrderMatched {
+            pk: Pubkey::new_unique(),
+            purchaser: Pubkey::new_unique(),
+            for_outcome: true,
+            outcome_index: 0,
+            price: 1.1,
+            stake: 10,
+        }
+    }
+}

--- a/programs/monaco_protocol/src/state/market_matching_queue_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_queue_account.rs
@@ -105,8 +105,12 @@ pub struct OrderMatched {
 }
 
 impl OrderMatched {
-    pub const SIZE: usize =
-        BOOL_SIZE + U16_SIZE + F64_SIZE + U64_SIZE + PUB_KEY_SIZE + PUB_KEY_SIZE;
+    pub const SIZE: usize = PUB_KEY_SIZE +  // pk
+    PUB_KEY_SIZE + // purchaser
+        BOOL_SIZE + //for_outcome
+         U16_SIZE + // outcome_index
+         F64_SIZE + // price
+         U64_SIZE; // stake
 }
 
 impl PartialEq for OrderMatched {
@@ -126,7 +130,7 @@ mod tests_matching_queue {
         let mut queue = MatchingQueue::new(10);
         assert_eq!(0, queue.len());
 
-        let result = queue.enqueue(order_match());
+        let result = queue.enqueue(OrderMatched::default());
         assert!(result.is_some());
         assert_eq!(0, result.unwrap());
         assert_eq!(1, queue.len());
@@ -135,11 +139,11 @@ mod tests_matching_queue {
     #[test]
     fn enqueue_some_queue() {
         let mut queue = MatchingQueue::new(10);
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
         assert_eq!(2, queue.len());
 
-        let result = queue.enqueue(order_match());
+        let result = queue.enqueue(OrderMatched::default());
         assert!(result.is_some());
         assert_eq!(2, result.unwrap());
         assert_eq!(3, queue.len());
@@ -148,19 +152,19 @@ mod tests_matching_queue {
     #[test]
     fn enqueue_full_queue() {
         let mut queue = MatchingQueue::new(10);
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
         assert_eq!(10, queue.len());
 
-        let result = queue.enqueue(order_match());
+        let result = queue.enqueue(OrderMatched::default());
         assert!(result.is_none());
         assert_eq!(10, queue.len());
     }
@@ -178,9 +182,9 @@ mod tests_matching_queue {
     #[test]
     fn dequeue_full_queue() {
         let mut queue = MatchingQueue::new(10);
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
         assert_eq!(3, queue.len());
 
         let result = queue.dequeue();
@@ -200,7 +204,7 @@ mod tests_matching_queue {
     #[test]
     fn peek_full_queue() {
         let mut queue = MatchingQueue::new(10);
-        let item = order_match();
+        let item = OrderMatched::default();
         queue.enqueue(item);
         assert_eq!(1, queue.len());
 
@@ -213,23 +217,12 @@ mod tests_matching_queue {
     #[test]
     fn peek_edit_in_place() {
         let mut queue = MatchingQueue::new(10);
-        queue.enqueue(order_match());
-        queue.enqueue(order_match());
+        queue.enqueue(OrderMatched::default());
+        queue.enqueue(OrderMatched::default());
         assert_eq!(2, queue.len());
 
         let result0 = queue.peek().unwrap();
         result0.stake = 10;
         assert_eq!(10, queue.items[0].stake);
-    }
-
-    fn order_match() -> OrderMatched {
-        OrderMatched {
-            pk: Pubkey::new_unique(),
-            purchaser: Pubkey::new_unique(),
-            for_outcome: true,
-            outcome_index: 0,
-            price: 1.1,
-            stake: 10,
-        }
     }
 }

--- a/programs/monaco_protocol/src/state/mod.rs
+++ b/programs/monaco_protocol/src/state/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod market_account;
 pub(crate) mod market_matching_pool_account;
+pub(crate) mod market_matching_queue_account;
 pub(crate) mod market_outcome_account;
 pub(crate) mod market_position_account;
 pub(crate) mod market_type;

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -291,6 +291,7 @@ describe("End to end test of", () => {
         market: market.pk,
         authority: monaco.operatorPk,
         marketEscrow: market.escrowPk,
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()

--- a/tests/market/create_market.ts
+++ b/tests/market/create_market.ts
@@ -7,7 +7,10 @@ import assert from "assert";
 import { findEscrowPda, findMarketPda } from "../../npm-client/src/";
 import { createNewMint, createWalletWithBalance } from "../util/test_util";
 import { Monaco, monaco } from "../util/wrappers";
-import { findCommissionPaymentsQueuePda } from "../../npm-admin-client";
+import {
+  findCommissionPaymentsQueuePda,
+  findMarketMatchingQueuePda,
+} from "../../npm-admin-client";
 import { getOrCreateMarketType } from "../../npm-admin-client/src/market_type_create";
 
 describe("Create markets with inplay features", () => {
@@ -50,10 +53,7 @@ describe("Market: creation", () => {
     assert.deepEqual(account.marketType, market.marketTypePk);
 
     // place some orders to ensure matching pools are created
-    const purchaser = await createWalletWithBalance(
-      monaco.provider,
-      1000000000,
-    );
+    const purchaser = await createWalletWithBalance(monaco.provider);
     await market.cachePurchaserTokenPk(purchaser.publicKey);
     await market.airdrop(purchaser, 100);
 
@@ -141,7 +141,9 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
     const marketPaymentQueuePk = (
       await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
     ).data.pda;
@@ -166,6 +168,7 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: marketPaymentQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
@@ -232,7 +235,9 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
     const marketPaymentQueuePk = (
       await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
     ).data.pda;
@@ -257,6 +262,7 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: marketPaymentQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
@@ -319,7 +325,9 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
     const marketPaymentQueuePk = (
       await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
     ).data.pda;
@@ -343,6 +351,7 @@ describe("Market: creation", () => {
         market: marketPk,
         marketType: marketTypePk,
         escrow: marketEscrowPk,
+        matchingQueue: matchingQueuePk,
         commissionPaymentQueue: marketPaymentQueuePk,
         mint: mintPk,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
@@ -485,7 +494,9 @@ async function createMarket(
   const marketEscrowPk = (
     await findEscrowPda(protocol.program as Program, marketPk)
   ).data.pda;
-
+  const matchingQueuePk = (
+    await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
+  ).data.pda;
   const marketPaymentQueuePk = (
     await findCommissionPaymentsQueuePda(protocol.program as Program, marketPk)
   ).data.pda;
@@ -509,6 +520,7 @@ async function createMarket(
       market: marketPk,
       marketType: marketTypePk,
       escrow: marketEscrowPk,
+      matchingQueue: matchingQueuePk,
       commissionPaymentQueue: marketPaymentQueuePk,
       mint: mintPk,
       rent: anchor.web3.SYSVAR_RENT_PUBKEY,

--- a/tests/market/recreate_market.ts
+++ b/tests/market/recreate_market.ts
@@ -3,6 +3,7 @@ import { findEscrowPda, findMarketPda } from "../../npm-client/src/";
 import { monaco } from "../util/wrappers";
 import {
   findCommissionPaymentsQueuePda,
+  findMarketMatchingQueuePda,
   getOrCreateMarketType,
 } from "../../npm-admin-client";
 import { createNewMint, createWalletWithBalance } from "../util/test_util";
@@ -29,6 +30,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -52,6 +56,7 @@ describe("Recreate markets", () => {
         market: marketPk,
         marketType: existingMarket.marketType,
         escrow: escrowPk,
+        matchingQueue: matchingQueuePk,
         commissionPaymentQueue: paymentsQueuePk,
         mint: existingMarket.mintAccount,
         marketOperator: monaco.operatorPk,
@@ -81,6 +86,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -105,6 +113,7 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: existingMarket.marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: existingMarket.mintAccount,
           marketOperator: monaco.operatorPk,
@@ -140,6 +149,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -164,6 +176,7 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: existingMarket.mintAccount,
           marketOperator: monaco.operatorPk,
@@ -209,6 +222,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -233,6 +249,7 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: existingMarket.marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: existingMarket.mintAccount,
           marketOperator: monaco.operatorPk,
@@ -278,6 +295,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -302,6 +322,7 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: existingMarket.marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: existingMarket.mintAccount,
           marketOperator: monaco.operatorPk,
@@ -339,6 +360,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -363,6 +387,7 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: existingMarket.marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: mint,
           marketOperator: monaco.operatorPk,
@@ -378,10 +403,7 @@ describe("Recreate markets", () => {
   it("fails if operator is not the same as existing market authority", async () => {
     const program = monaco.program as Program;
 
-    const newOperator = await createWalletWithBalance(
-      monaco.provider,
-      100000000,
-    );
+    const newOperator = await createWalletWithBalance(monaco.provider);
     await monaco.authoriseMarketOperator(newOperator);
 
     const existingMarketWrapper = await monaco.create3WayMarket([2, 3, 4]);
@@ -400,6 +422,9 @@ describe("Recreate markets", () => {
       )
     ).data.pda;
     const escrowPk = (await findEscrowPda(program, marketPk)).data.pda;
+    const matchingQueuePk = (
+      await findMarketMatchingQueuePda(program, marketPk)
+    ).data.pda;
     const paymentsQueuePk = (
       await findCommissionPaymentsQueuePda(program, marketPk)
     ).data.pda;
@@ -424,13 +449,18 @@ describe("Recreate markets", () => {
           market: marketPk,
           marketType: existingMarket.marketType,
           escrow: escrowPk,
+          matchingQueue: matchingQueuePk,
           commissionPaymentQueue: paymentsQueuePk,
           mint: existingMarket.mintAccount,
           marketOperator: newOperator.publicKey,
           authorisedOperators: await monaco.findMarketAuthorisedOperatorsPda(),
         })
         .signers([newOperator])
-        .rpc();
+        .rpc()
+        .catch((e) => {
+          console.error(e);
+          throw e;
+        });
       fail("Should have thrown");
     } catch (e) {
       expect(e.error.errorCode.code).toMatch("MarketAuthorityMismatch");

--- a/tests/market/recreate_market.ts
+++ b/tests/market/recreate_market.ts
@@ -456,11 +456,7 @@ describe("Recreate markets", () => {
           authorisedOperators: await monaco.findMarketAuthorisedOperatorsPda(),
         })
         .signers([newOperator])
-        .rpc()
-        .catch((e) => {
-          console.error(e);
-          throw e;
-        });
+        .rpc();
       fail("Should have thrown");
     } catch (e) {
       expect(e.error.errorCode.code).toMatch("MarketAuthorityMismatch");

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -39,6 +39,9 @@ describe("Close market accounts (settled)", () => {
     const escrowRent = await monaco.provider.connection.getBalance(
       market.escrowPk,
     );
+    const matchingQueueRent = await monaco.provider.connection.getBalance(
+      market.matchingQueuePk,
+    );
     const paymentsQueueRent = await monaco.provider.connection.getBalance(
       market.paymentsQueuePk,
     );
@@ -48,6 +51,7 @@ describe("Close market accounts (settled)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })
@@ -62,6 +66,7 @@ describe("Close market accounts (settled)", () => {
       balanceMarketCreated +
       marketRent +
       escrowRent +
+      matchingQueueRent +
       paymentsQueueRent +
       outcomeARent +
       outcomeBRent;
@@ -106,6 +111,7 @@ describe("Close market accounts (settled)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })
@@ -138,6 +144,7 @@ describe("Close market accounts (settled)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: monaco.operatorPk,
       })
@@ -184,6 +191,7 @@ describe("Close market accounts (settled)", () => {
       .accounts({
         market: marketB.pk,
         marketEscrow: marketB.escrowPk,
+        matchingQueue: marketB.matchingQueuePk,
         commissionPaymentQueue: marketB.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })
@@ -217,6 +225,7 @@ describe("Close market accounts (settled)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })

--- a/tests/protocol/close_market_voided.ts
+++ b/tests/protocol/close_market_voided.ts
@@ -39,6 +39,9 @@ describe("Close market accounts (voided)", () => {
     const escrowRent = await monaco.provider.connection.getBalance(
       market.escrowPk,
     );
+    const matchingQueueRent = await monaco.provider.connection.getBalance(
+      market.matchingQueuePk,
+    );
     const paymentsQueueRent = await monaco.provider.connection.getBalance(
       market.paymentsQueuePk,
     );
@@ -48,9 +51,9 @@ describe("Close market accounts (voided)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
-        authority: marketOperator.publicKey,
-
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
+        authority: marketOperator.publicKey,
       })
       .rpc()
       .catch((e) => console.log(e));
@@ -63,6 +66,7 @@ describe("Close market accounts (voided)", () => {
       balanceMarketCreated +
       marketRent +
       escrowRent +
+      matchingQueueRent +
       paymentsQueueRent +
       outcomeARent +
       outcomeBRent;
@@ -107,9 +111,9 @@ describe("Close market accounts (voided)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
-        authority: marketOperator.publicKey,
-
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
+        authority: marketOperator.publicKey,
       })
       .rpc()
       .catch((e) => {
@@ -140,9 +144,9 @@ describe("Close market accounts (voided)", () => {
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
-        authority: monaco.operatorPk,
-
+        matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
+        authority: monaco.operatorPk,
       })
       .rpc()
       .catch((e) => {
@@ -187,9 +191,9 @@ describe("Close market accounts (voided)", () => {
       .accounts({
         market: marketB.pk,
         marketEscrow: marketB.escrowPk,
-        authority: marketOperator.publicKey,
-
+        matchingQueue: marketB.matchingQueuePk,
         commissionPaymentQueue: marketB.paymentsQueuePk,
+        authority: marketOperator.publicKey,
       })
       .rpc()
       .catch((e) => {

--- a/tests/util/test_util.ts
+++ b/tests/util/test_util.ts
@@ -42,6 +42,7 @@ import console from "console";
 import * as idl from "../anchor/protocol_product/protocol_product.json";
 import {
   findCommissionPaymentsQueuePda,
+  findMarketMatchingQueuePda,
   PaymentInfo,
 } from "../../npm-admin-client";
 import { getOrCreateMarketType as getOrCreateMarketTypeClient } from "../../npm-admin-client/src/market_type_create";
@@ -239,7 +240,11 @@ export async function createMarket(
   const escrowPda = (await findEscrowPda(protocolProgram as Program, marketPda))
     .data.pda;
 
-  const paymentsQueuePda = (
+  const matchingQueuePda = (
+    await findMarketMatchingQueuePda(protocolProgram as Program, marketPda)
+  ).data.pda;
+
+  const commissionPaymentQueuePda = (
     await findCommissionPaymentsQueuePda(protocolProgram as Program, marketPda)
   ).data.pda;
 
@@ -268,7 +273,8 @@ export async function createMarket(
       rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       authorisedOperators: authorisedMarketOperators,
       marketOperator: marketOperator.publicKey,
-      commissionPaymentQueue: paymentsQueuePda,
+      matchingQueue: matchingQueuePda,
+      commissionPaymentQueue: commissionPaymentQueuePda,
     })
     .signers([marketOperator])
     .rpc();
@@ -365,7 +371,8 @@ export async function createMarket(
     outcomes,
     mintPk,
     escrowPda,
-    paymentsQueuePda,
+    matchingQueuePda,
+    paymentsQueuePda: commissionPaymentQueuePda,
     outcomePdas,
     matchingPools,
     authorisedMarketOperators,


### PR DESCRIPTION
Introducing market matching queue account. Protocol was updated to create the account during market creation and close it when market is closed. Nothing more.

This change is safe to go to production even if we do not push the matching changes themselves. The only consequence is that market creation will become slightly more expensive.