### PR TITLE
fix: surplus can only be transferred out when settled or voided and before closure

### DIFF
--- a/programs/monaco_protocol/src/instructions/market/escrow.rs
+++ b/programs/monaco_protocol/src/instructions/market/escrow.rs
@@ -9,11 +9,8 @@ use anchor_lang::{Key, ToAccountInfo};
 use anchor_spl::token;
 use anchor_spl::token::{Token, TokenAccount};
 
-const TRANSFER_SURPLUS_ALLOWED_STATUSES: [MarketStatus; 3] = [
-    MarketStatus::Settled,
-    MarketStatus::ReadyToClose,
-    MarketStatus::Voided,
-];
+const TRANSFER_SURPLUS_ALLOWED_STATUSES: [MarketStatus; 2] =
+    [MarketStatus::Settled, MarketStatus::Voided];
 
 pub fn transfer_market_escrow_surplus<'info>(
     market: &Account<'info, Market>,


### PR DESCRIPTION
Transferring market escrow surplus should only be allowed after all other transfers were executed and before market gets closed. The market status indicating that is currently either `Settled` or `Voided`. Therefor removing the `ReadyToClose` which would allow funds to be lost.