### PR TITLE
fix: canceled orders should not be allowed to be settled again

### DIFF
--- a/programs/monaco_protocol/src/instructions/order/settle_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/settle_order.rs
@@ -3,7 +3,7 @@ use solana_program::log;
 
 use crate::context::SettleOrder;
 use crate::error::CoreError;
-use crate::state::order_account::OrderStatus::{Open, SettledLose, SettledWin};
+use crate::state::order_account::OrderStatus::{Cancelled, Open, SettledLose, SettledWin};
 use crate::{Market, Order};
 
 pub fn settle_order(ctx: Context<SettleOrder>) -> Result<()> {
@@ -16,6 +16,10 @@ pub fn settle_order(ctx: Context<SettleOrder>) -> Result<()> {
     );
 
     // exit early if already settled
+    if Cancelled.eq(&ctx.accounts.order.order_status) {
+        log::sol_log("order already cancelled");
+        return Ok(());
+    }
     if SettledLose.eq(&ctx.accounts.order.order_status) {
         log::sol_log("order already settled as loss");
         return Ok(());

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -102,7 +102,7 @@ pub mod monaco_protocol {
         ctx: Context<CancelPreplayOrderPostEventStart>,
     ) -> Result<()> {
         let refund_amount = instructions::order::cancel_preplay_order_post_event_start(
-            &ctx.accounts.market,
+            &mut ctx.accounts.market,
             &mut ctx.accounts.market_matching_pool,
             &mut ctx.accounts.order,
             &mut ctx.accounts.market_position,

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -156,9 +156,11 @@ describe("End to end test of", () => {
     assert.equal(order.stakeUnmatched, 0);
 
     // Close orders due to event start
+    assert.deepEqual((await market.getAccount()).unsettledAccountsCount, 13);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder03);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder10);
     await market.cancelPreplayOrderPostEventStart(prePlayOrder11);
+    assert.deepEqual((await market.getAccount()).unsettledAccountsCount, 10);
 
     order = await monaco.getOrder(prePlayOrder01);
     assert.equal(order.stakeUnmatched, 0);
@@ -181,6 +183,9 @@ describe("End to end test of", () => {
         }
       });
     await market.completeSettlement();
+    const marketAccount = await market.getAccount();
+    assert.equal(marketAccount.unsettledAccountsCount, 0);
+    assert.equal(marketAccount.unclosedAccountsCount, 22);
 
     // Close accounts
     await market.readyToClose();


### PR DESCRIPTION
If order was canceled as a whole it should not go through settlement process since it was already paid out (or rather paid back). To keep the market consistency counters correct it means the cancel method needs to decrement them now when needed.