### PR TITLE
fix: copy product commission contributions when matching orders

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -190,7 +190,5 @@ fn copy_market_position(from: &MarketPosition, to: &mut MarketPosition) {
 }
 
 fn copy_product_commission_contributions(from: &MarketPosition, to: &mut MarketPosition) {
-    for index in 0..from.matched_risk_per_product.len() {
-        to.matched_risk_per_product[index] = from.matched_risk_per_product[index];
-    }
+    to.matched_risk_per_product = from.matched_risk_per_product.clone();
 }

--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -118,11 +118,17 @@ pub fn match_orders(ctx: &mut Context<MatchOrders>) -> Result<()> {
 
     // update product commission tracking for matched risk
     update_product_commission_contributions(market_position_for, order_for, stake_matched)?;
+    if market_position_identical {
+        copy_product_commission_contributions(market_position_for, market_position_against);
+    }
     update_product_commission_contributions(
         market_position_against,
         order_against,
         calculate_risk_from_stake(stake_matched, selected_price),
     )?;
+    if market_position_identical {
+        copy_product_commission_contributions(market_position_against, market_position_for);
+    }
 
     // 3. market update
     // -----------------------------
@@ -180,5 +186,11 @@ fn copy_market_position(from: &MarketPosition, to: &mut MarketPosition) {
     for index in 0..from.market_outcome_sums.len() {
         to.market_outcome_sums[index] = from.market_outcome_sums[index];
         to.unmatched_exposures[index] = from.unmatched_exposures[index];
+    }
+}
+
+fn copy_product_commission_contributions(from: &MarketPosition, to: &mut MarketPosition) {
+    for index in 0..from.matched_risk_per_product.len() {
+        to.matched_risk_per_product[index] = from.matched_risk_per_product[index];
     }
 }

--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -15,7 +15,7 @@ pub struct MarketPosition {
     pub matched_risk_per_product: Vec<ProductMatchedRiskAndRate>,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, PartialEq)]
 pub struct ProductMatchedRiskAndRate {
     pub product: Pubkey,
     pub risk: u64,

--- a/tests/protocol/product_commission_matching.ts
+++ b/tests/protocol/product_commission_matching.ts
@@ -566,4 +566,66 @@ describe("Product commissions", () => {
       match2ExpectedRisk,
     );
   });
+
+  it("matched orders - single match for the same user with different products", async () => {
+    const market = await monaco.create3WayMarket([2.0]);
+    const purchaser = await createWalletWithBalance(monaco.provider);
+    await market.airdrop(purchaser, 1000);
+
+    const product1Commission = 5;
+    const product1Pk = await externalPrograms.createProduct(
+      "MONACO_EXCHANGE_9A",
+      product1Commission,
+    );
+    const product2Commission = 10;
+    const product2Pk = await externalPrograms.createProduct(
+      "MONACO_EXCHANGE_9B",
+      product2Commission,
+    );
+
+    const stake = 20;
+    const forOrderPk = await market.forOrder(
+      0,
+      stake,
+      2.0,
+      purchaser,
+      product1Pk,
+    );
+    const againstOrderPk = await market.againstOrder(
+      0,
+      stake,
+      2.0,
+      purchaser,
+      product2Pk,
+    );
+    await market.match(forOrderPk, againstOrderPk);
+
+    const marketPositionPk = await findMarketPositionPda(
+      monaco.getRawProgram(),
+      market.pk,
+      purchaser.publicKey,
+    );
+    const marketPosition = await monaco.fetchMarketPosition(
+      marketPositionPk.data.pda,
+    );
+    const expectedMatchedStake = stake * 10 ** market.mintInfo.decimals;
+
+    assert.equal(marketPosition.matchedRiskPerProduct.length, 2);
+
+    const matchedStakeForProduct = marketPosition.matchedRiskPerProduct[0];
+    assert.equal(
+      matchedStakeForProduct.product.toBase58(),
+      product1Pk.toBase58(),
+    );
+    assert.equal(matchedStakeForProduct.risk.toNumber(), expectedMatchedStake);
+    assert.equal(matchedStakeForProduct.rate, product1Commission);
+
+    const matchedStakeForProduct2 = marketPosition.matchedRiskPerProduct[1];
+    assert.equal(
+      matchedStakeForProduct2.product.toBase58(),
+      product2Pk.toBase58(),
+    );
+    assert.equal(matchedStakeForProduct2.risk.toNumber(), expectedMatchedStake);
+    assert.equal(matchedStakeForProduct2.rate, product2Commission);
+  });
 });


### PR DESCRIPTION
One of the edge cases of our matching algorithm is that orders owned by the same users can be matched. Let's suppose they were created in the context of two separate products in which case both should be recorded accordingly. Unfortunately this was not happening correctly and that's what's being fixed here.