### PR TITLE
fix: copy product commission contributions when matching orders (2)

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_one_to_one.rs
@@ -190,5 +190,6 @@ fn copy_market_position(from: &MarketPosition, to: &mut MarketPosition) {
 }
 
 fn copy_product_commission_contributions(from: &MarketPosition, to: &mut MarketPosition) {
+    to.matched_risk = from.matched_risk;
     to.matched_risk_per_product = from.matched_risk_per_product.clone();
 }

--- a/tests/protocol/product_commission_matching.ts
+++ b/tests/protocol/product_commission_matching.ts
@@ -610,6 +610,7 @@ describe("Product commissions", () => {
     );
     const expectedMatchedStake = stake * 10 ** market.mintInfo.decimals;
 
+    assert.equal(marketPosition.matchedRisk.toNumber(), stake * 2 * 1_000_000); // two stakes of 20
     assert.equal(marketPosition.matchedRiskPerProduct.length, 2);
 
     const matchedStakeForProduct = marketPosition.matchedRiskPerProduct[0];


### PR DESCRIPTION
part 2 to https://github.com/MonacoProtocol/protocol/pull/149

> One of the edge cases of our matching algorithm is that orders owned by the same users can be matched. Let's suppose they were created in the context of two separate products in which case both should be recorded accordingly. Unfortunately this was not happening correctly and that's what's being fixed here.

Forgot to copy the sum as well as parts of the matched risk.

