### PR TITLE
fix: remove empty string market type discrim and value condition from market creation

### DIFF
--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -51,14 +51,11 @@ pub fn create(
     require!(PRICE_SCALE <= decimal_limit, CoreError::MaxDecimalsTooLarge);
 
     require!(
-        ctx.accounts.market_type.requires_discriminator
-            == (market_type_discriminator.is_some()
-                && !market_type_discriminator.as_ref().unwrap().is_empty()),
+        ctx.accounts.market_type.requires_discriminator == market_type_discriminator.is_some(),
         CoreError::MarketTypeDiscriminatorUsageIncorrect
     );
     require!(
-        ctx.accounts.market_type.requires_value
-            == (market_type_value.is_some() && !market_type_value.as_ref().unwrap().is_empty()),
+        ctx.accounts.market_type.requires_value == market_type_value.is_some(),
         CoreError::MarketTypeValueUsageIncorrect
     );
 

--- a/tests/market/create_market.ts
+++ b/tests/market/create_market.ts
@@ -94,7 +94,179 @@ describe("Market: creation", () => {
     );
   });
 
-  it("failure when type discriminator used but not required by market type", async () => {
+  it("success when market type discriminator and value are provided appropriately", async () => {
+    const marketTypeDiscriminator = "foo";
+    const marketTypeValue = "bar";
+
+    const marketType = "TypeWithDiscrimAndValue";
+    const marketTypeResp = await getOrCreateMarketType(
+      monaco.program as Program,
+      marketType,
+      true,
+      true,
+    );
+    if (!marketTypeResp.success) {
+      throw new Error(marketTypeResp.errors[0].toString());
+    }
+    const marketTypePk = marketTypeResp.data.publicKey;
+
+    const mintDecimals = 6;
+    const marketDecimals = 3;
+    const event = Keypair.generate();
+    const marketTitle = "SOME TITLE";
+    const now = Math.floor(new Date().getTime() / 1000);
+    const marketLockTimestamp = now + 1000;
+    const eventStartTimestamp = marketLockTimestamp;
+
+    const [mintPk, authorisedOperatorsPk] = await Promise.all([
+      createNewMint(
+        monaco.provider,
+        monaco.provider.wallet as NodeWallet,
+        mintDecimals,
+      ),
+      monaco.findMarketAuthorisedOperatorsPda(),
+    ]);
+
+    const marketPk = (
+      await findMarketPda(
+        monaco.program as Program,
+        event.publicKey,
+        marketTypePk,
+        marketTypeDiscriminator,
+        marketTypeValue,
+        mintPk,
+      )
+    ).data.pda;
+
+    const marketEscrowPk = (
+      await findEscrowPda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    const marketPaymentQueuePk = (
+      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    await monaco.program.methods
+      .createMarket(
+        event.publicKey,
+        marketTypeDiscriminator,
+        marketTypeValue,
+        marketTitle,
+        marketDecimals,
+        new anchor.BN(marketLockTimestamp),
+        new anchor.BN(eventStartTimestamp),
+        false,
+        0,
+        { none: {} },
+        { none: {} },
+      )
+      .accounts({
+        existingMarket: null,
+        market: marketPk,
+        marketType: marketTypePk,
+        escrow: marketEscrowPk,
+        commissionPaymentQueue: marketPaymentQueuePk,
+        mint: mintPk,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        authorisedOperators: authorisedOperatorsPk,
+        marketOperator: monaco.operatorPk,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .rpc();
+  });
+
+  it("failure when market type discriminator contains the seed separator", async () => {
+    const marketTypeDiscriminator = "a market ␞ discriminator";
+    const marketTypeValue = "bar";
+
+    const marketType = "TypeWithDiscrimAndValue";
+    const marketTypeResp = await getOrCreateMarketType(
+      monaco.program as Program,
+      marketType,
+      true,
+      true,
+    );
+    if (!marketTypeResp.success) {
+      throw new Error(marketTypeResp.errors[0].toString());
+    }
+    const marketTypePk = marketTypeResp.data.publicKey;
+
+    const mintDecimals = 6;
+    const marketDecimals = 3;
+    const event = Keypair.generate();
+    const marketTitle = "SOME TITLE";
+    const now = Math.floor(new Date().getTime() / 1000);
+    const marketLockTimestamp = now + 1000;
+    const eventStartTimestamp = marketLockTimestamp;
+
+    const [mintPk, authorisedOperatorsPk] = await Promise.all([
+      createNewMint(
+        monaco.provider,
+        monaco.provider.wallet as NodeWallet,
+        mintDecimals,
+      ),
+      monaco.findMarketAuthorisedOperatorsPda(),
+    ]);
+
+    const marketPk = (
+      await findMarketPda(
+        monaco.program as Program,
+        event.publicKey,
+        marketTypePk,
+        marketTypeDiscriminator,
+        marketTypeValue,
+        mintPk,
+      )
+    ).data.pda;
+
+    const marketEscrowPk = (
+      await findEscrowPda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    const marketPaymentQueuePk = (
+      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    try {
+      await monaco.program.methods
+        .createMarket(
+          event.publicKey,
+          marketTypeDiscriminator,
+          marketTypeValue,
+          marketTitle,
+          marketDecimals,
+          new anchor.BN(marketLockTimestamp),
+          new anchor.BN(eventStartTimestamp),
+          false,
+          0,
+          { none: {} },
+          { none: {} },
+        )
+        .accounts({
+          existingMarket: null,
+          market: marketPk,
+          marketType: marketTypePk,
+          escrow: marketEscrowPk,
+          commissionPaymentQueue: marketPaymentQueuePk,
+          mint: mintPk,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+          authorisedOperators: authorisedOperatorsPk,
+          marketOperator: monaco.operatorPk,
+          systemProgram: SystemProgram.programId,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .rpc();
+      assert.fail("Expected an exception to be thrown");
+    } catch (err) {
+      assert.equal(
+        err.error.errorCode.code,
+        "MarketTypeDiscriminatorContainsSeedSeparator",
+      );
+    }
+  });
+
+  it("failure when type discriminator provided but not required by market type", async () => {
     const marketTypeDiscriminator = "Foobar";
     const marketTypeValue = null;
 
@@ -184,7 +356,97 @@ describe("Market: creation", () => {
     }
   });
 
-  it("failure when type value used but not required by market type", async () => {
+  it("failure when type discriminator not provided but is required by market type", async () => {
+    const marketTypeDiscriminator = null;
+    const marketTypeValue = null;
+
+    const marketType = "DiscrimOnly";
+    const marketTypeResp = await getOrCreateMarketType(
+      monaco.program as Program,
+      marketType,
+      true,
+      false,
+    );
+    if (!marketTypeResp.success) {
+      throw new Error(marketTypeResp.errors[0].toString());
+    }
+    const marketTypePk = marketTypeResp.data.publicKey;
+
+    const mintDecimals = 6;
+    const marketDecimals = 3;
+    const event = Keypair.generate();
+    const marketTitle = "SOME TITLE";
+    const now = Math.floor(new Date().getTime() / 1000);
+    const marketLockTimestamp = now + 1000;
+    const eventStartTimestamp = marketLockTimestamp;
+
+    const [mintPk, authorisedOperatorsPk] = await Promise.all([
+      createNewMint(
+        monaco.provider,
+        monaco.provider.wallet as NodeWallet,
+        mintDecimals,
+      ),
+      monaco.findMarketAuthorisedOperatorsPda(),
+    ]);
+
+    const marketPk = (
+      await findMarketPda(
+        monaco.program as Program,
+        event.publicKey,
+        marketTypePk,
+        marketTypeDiscriminator,
+        marketTypeValue,
+        mintPk,
+      )
+    ).data.pda;
+
+    const marketEscrowPk = (
+      await findEscrowPda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    const marketPaymentQueuePk = (
+      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
+    ).data.pda;
+
+    try {
+      await monaco.program.methods
+        .createMarket(
+          event.publicKey,
+          marketTypeDiscriminator,
+          marketTypeValue,
+          marketTitle,
+          marketDecimals,
+          new anchor.BN(marketLockTimestamp),
+          new anchor.BN(eventStartTimestamp),
+          false,
+          0,
+          { none: {} },
+          { none: {} },
+        )
+        .accounts({
+          existingMarket: null,
+          market: marketPk,
+          marketType: marketTypePk,
+          escrow: marketEscrowPk,
+          commissionPaymentQueue: marketPaymentQueuePk,
+          mint: mintPk,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+          authorisedOperators: authorisedOperatorsPk,
+          marketOperator: monaco.operatorPk,
+          systemProgram: SystemProgram.programId,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .rpc();
+      assert.fail("Expected to fail");
+    } catch (err) {
+      assert.equal(
+        err.error.errorCode.code,
+        "MarketTypeDiscriminatorUsageIncorrect",
+      );
+    }
+  });
+
+  it("failure when type value provided but not required by market type", async () => {
     const marketTypeValue = "Foobar";
     const marketTypeDiscriminator = null;
 
@@ -272,97 +534,15 @@ describe("Market: creation", () => {
     }
   });
 
-  it("success with market type discriminator and value provided appropriately", async () => {
-    const marketTypeDiscriminator = "foo";
-    const marketTypeValue = "bar";
+  it("failure when type value not provided but is required by market type", async () => {
+    const marketTypeDiscriminator = null;
+    const marketTypeValue = null;
 
-    const marketType = "TypeWithDiscrimAndValue";
+    const marketType = "ValueOnly";
     const marketTypeResp = await getOrCreateMarketType(
       monaco.program as Program,
       marketType,
-      true,
-      true,
-    );
-    if (!marketTypeResp.success) {
-      throw new Error(marketTypeResp.errors[0].toString());
-    }
-    const marketTypePk = marketTypeResp.data.publicKey;
-
-    const mintDecimals = 6;
-    const marketDecimals = 3;
-    const event = Keypair.generate();
-    const marketTitle = "SOME TITLE";
-    const now = Math.floor(new Date().getTime() / 1000);
-    const marketLockTimestamp = now + 1000;
-    const eventStartTimestamp = marketLockTimestamp;
-
-    const [mintPk, authorisedOperatorsPk] = await Promise.all([
-      createNewMint(
-        monaco.provider,
-        monaco.provider.wallet as NodeWallet,
-        mintDecimals,
-      ),
-      monaco.findMarketAuthorisedOperatorsPda(),
-    ]);
-
-    const marketPk = (
-      await findMarketPda(
-        monaco.program as Program,
-        event.publicKey,
-        marketTypePk,
-        marketTypeDiscriminator,
-        marketTypeValue,
-        mintPk,
-      )
-    ).data.pda;
-
-    const marketEscrowPk = (
-      await findEscrowPda(monaco.program as Program, marketPk)
-    ).data.pda;
-
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-
-    await monaco.program.methods
-      .createMarket(
-        event.publicKey,
-        marketTypeDiscriminator,
-        marketTypeValue,
-        marketTitle,
-        marketDecimals,
-        new anchor.BN(marketLockTimestamp),
-        new anchor.BN(eventStartTimestamp),
-        false,
-        0,
-        { none: {} },
-        { none: {} },
-      )
-      .accounts({
-        existingMarket: null,
-        market: marketPk,
-        marketType: marketTypePk,
-        escrow: marketEscrowPk,
-        commissionPaymentQueue: marketPaymentQueuePk,
-        mint: mintPk,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        authorisedOperators: authorisedOperatorsPk,
-        marketOperator: monaco.operatorPk,
-        systemProgram: SystemProgram.programId,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .rpc();
-  });
-
-  it("failure with market type discriminator containing the seed separator", async () => {
-    const marketTypeDiscriminator = "a market ␞ discriminator";
-    const marketTypeValue = "bar";
-
-    const marketType = "TypeWithDiscrimAndValue";
-    const marketTypeResp = await getOrCreateMarketType(
-      monaco.program as Program,
-      marketType,
-      true,
+      false,
       true,
     );
     if (!marketTypeResp.success) {
@@ -435,12 +615,9 @@ describe("Market: creation", () => {
           tokenProgram: TOKEN_PROGRAM_ID,
         })
         .rpc();
-      assert.fail("Expected an exception to be thrown");
+      assert.fail("Expected to fail");
     } catch (err) {
-      assert.equal(
-        err.error.errorCode.code,
-        "MarketTypeDiscriminatorContainsSeedSeparator",
-      );
+      assert.equal(err.error.errorCode.code, "MarketTypeValueUsageIncorrect");
     }
   });
 


### PR DESCRIPTION
Remove missed existing validation conditions that incorrectly allowed empty string to be provided as market type discriminator and/or market type value during market creation when they should have been `null`/`None` according to the market type used. 