### PR TITLE
feat: create queues when opening markets

### DIFF
--- a/npm-admin-client/src/market_management.ts
+++ b/npm-admin-client/src/market_management.ts
@@ -13,7 +13,11 @@ import {
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
-import { findEscrowPda } from "./market_helpers";
+import {
+  findCommissionPaymentsQueuePda,
+  findEscrowPda,
+  findMarketMatchingQueuePda,
+} from "./market_helpers";
 
 /**
  * Settle a market by setting the winningOutcomeIndex
@@ -444,11 +448,20 @@ export async function openMarket(
     return response.body;
   }
 
+  const matchingQueue = await findMarketMatchingQueuePda(program, marketPk);
+
+  const commissionQueue = await findCommissionPaymentsQueuePda(
+    program,
+    marketPk,
+  );
+
   try {
     const tnxId = await program.methods
       .openMarket()
       .accounts({
         market: marketPk,
+        matchingQueue: matchingQueue.data.pda,
+        commissionPaymentQueue: commissionQueue.data.pda,
         authorisedOperators: authorisedOperators.data.pda,
         marketOperator: provider.wallet.publicKey,
       })

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -717,7 +717,7 @@ pub struct OpenMarket<'info> {
         payer = market_operator,
         space = MarketMatchingQueue::SIZE
     )]
-    pub matching_queue: Box<Account<'info, MarketMatchingQueue>>,
+    pub matching_queue: Account<'info, MarketMatchingQueue>,
     #[account(
         init,
         seeds = [

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -568,28 +568,6 @@ pub struct CreateMarket<'info> {
         token::authority = escrow
     )]
     pub escrow: Account<'info, TokenAccount>,
-    #[account(
-        init,
-        seeds = [
-            b"matching".as_ref(),
-            market.key().as_ref(),
-        ],
-        bump,
-        payer = market_operator,
-        space = MarketMatchingQueue::SIZE
-    )]
-    pub matching_queue: Box<Account<'info, MarketMatchingQueue>>,
-    #[account(
-        init,
-        seeds = [
-            b"commission_payments".as_ref(),
-            market.key().as_ref(),
-        ],
-        bump,
-        payer = market_operator,
-        space = MarketPaymentsQueue::SIZE
-    )]
-    pub commission_payment_queue: Account<'info, MarketPaymentsQueue>,
 
     pub market_type: Account<'info, MarketType>,
 
@@ -722,6 +700,42 @@ pub struct UpdateMarket<'info> {
     pub market_operator: Signer<'info>,
     #[account(seeds = [b"authorised_operators".as_ref(), b"MARKET".as_ref()], bump)]
     pub authorised_operators: Account<'info, AuthorisedOperators>,
+}
+
+#[derive(Accounts)]
+pub struct OpenMarket<'info> {
+    #[account(mut)]
+    pub market: Account<'info, Market>,
+
+    #[account(
+        init,
+        seeds = [
+            b"matching".as_ref(),
+            market.key().as_ref(),
+        ],
+        bump,
+        payer = market_operator,
+        space = MarketMatchingQueue::SIZE
+    )]
+    pub matching_queue: Box<Account<'info, MarketMatchingQueue>>,
+    #[account(
+        init,
+        seeds = [
+            b"commission_payments".as_ref(),
+            market.key().as_ref(),
+        ],
+        bump,
+        payer = market_operator,
+        space = MarketPaymentsQueue::SIZE
+    )]
+    pub commission_payment_queue: Account<'info, MarketPaymentsQueue>,
+
+    #[account(mut)]
+    pub market_operator: Signer<'info>,
+    #[account(seeds = [b"authorised_operators".as_ref(), b"MARKET".as_ref()], bump)]
+    pub authorised_operators: Account<'info, AuthorisedOperators>,
+
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
@@ -900,6 +914,29 @@ pub struct CloseMarketOutcome<'info> {
 }
 
 #[derive(Accounts)]
+pub struct CloseMarketQueues<'info> {
+    #[account(
+        mut,
+        has_one = market @ CoreError::CloseAccountMarketMismatch,
+        close = authority,
+    )]
+    pub matching_queue: Account<'info, MarketMatchingQueue>,
+    #[account(
+        mut,
+        has_one = market @ CoreError::CloseAccountMarketMismatch,
+        close = authority,
+    )]
+    pub commission_payment_queue: Account<'info, MarketPaymentsQueue>,
+    #[account(
+        mut,
+        has_one = authority @ CoreError::CloseAccountPurchaserMismatch,
+    )]
+    pub market: Account<'info, Market>,
+    #[account(mut)]
+    pub authority: SystemAccount<'info>,
+}
+
+#[derive(Accounts)]
 pub struct CloseMarket<'info> {
     #[account(
         mut,
@@ -915,22 +952,6 @@ pub struct CloseMarket<'info> {
         bump,
     )]
     pub market_escrow: Account<'info, TokenAccount>,
-    #[account(
-        mut,
-        has_one = market @ CoreError::CloseAccountMarketMismatch,
-        seeds = [b"matching".as_ref(), market.key().as_ref()],
-        bump,
-        close = authority,
-    )]
-    pub matching_queue: Account<'info, MarketMatchingQueue>,
-    #[account(
-        mut,
-        has_one = market @ CoreError::CloseAccountMarketMismatch,
-        seeds = [b"commission_payments".as_ref(), market.key().as_ref()],
-        bump,
-        close = authority,
-    )]
-    pub commission_payment_queue: Account<'info, MarketPaymentsQueue>,
 
     #[account(mut)]
     pub authority: SystemAccount<'info>,

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -283,6 +283,8 @@ pub enum CoreError {
     CloseAccountPayerMismatch,
     #[msg("CloseAccount: Market does not match")]
     CloseAccountMarketMismatch,
-    #[msg("CloseAccount: Market payment queue is not empty.")]
+    #[msg("CloseAccount: Market payment queue is not empty")]
     CloseAccountMarketPaymentQueueNotEmpty,
+    #[msg("CloseAccount: Market matching queue is not empty")]
+    CloseAccountMarketMatchingQueueNotEmpty,
 }

--- a/programs/monaco_protocol/src/instructions/close.rs
+++ b/programs/monaco_protocol/src/instructions/close.rs
@@ -3,7 +3,9 @@ use anchor_lang::prelude::*;
 use crate::error::CoreError;
 use crate::state::market_account::MarketStatus::ReadyToClose;
 use crate::state::market_account::{Market, MarketStatus};
+use crate::state::market_matching_queue_account::MatchingQueue;
 use crate::state::order_account::Order;
+use crate::state::payments_queue::PaymentQueue;
 
 pub fn close_market_child_account(market: &mut Market) -> Result<()> {
     require!(
@@ -21,18 +23,32 @@ pub fn close_order(market: &mut Market, order: &Order) -> Result<()> {
     close_market_child_account(market)
 }
 
-pub fn close_market(
-    market_status: &MarketStatus,
-    payment_queue_len: u32,
-    unclosed_accounts_count: u32,
+pub fn close_market_queues(
+    market: &mut Market,
+    payment_queue: &PaymentQueue,
+    matching_queue: &MatchingQueue,
 ) -> Result<()> {
     require!(
-        ReadyToClose.eq(market_status),
+        ReadyToClose.eq(&market.market_status),
         CoreError::MarketNotReadyToClose
     );
     require!(
-        payment_queue_len == 0,
+        payment_queue.len() == 0,
         CoreError::CloseAccountMarketPaymentQueueNotEmpty
+    );
+    require!(
+        matching_queue.len() == 0,
+        CoreError::CloseAccountMarketMatchingQueueNotEmpty
+    );
+
+    market.decrement_unclosed_accounts_count()?;
+    market.decrement_unclosed_accounts_count()
+}
+
+pub fn close_market(market_status: &MarketStatus, unclosed_accounts_count: u32) -> Result<()> {
+    require!(
+        ReadyToClose.eq(market_status),
+        CoreError::MarketNotReadyToClose
     );
     require!(
         unclosed_accounts_count == 0,
@@ -46,7 +62,9 @@ mod tests {
     use super::*;
     use crate::state::market_account::MarketOrderBehaviour;
     use crate::state::market_account::MarketStatus::Open;
+    use crate::state::market_matching_queue_account::OrderMatched;
     use crate::state::order_account::OrderStatus;
+    use crate::state::payments_queue::PaymentInfo;
 
     // generic close account validation
 
@@ -68,6 +86,79 @@ mod tests {
         let result = close_market_child_account(market);
         assert!(result.is_err());
         assert_eq!(Err(error!(CoreError::MarketNotReadyToClose)), result);
+    }
+
+    // close queues validation
+
+    #[test]
+    fn test_close_market_queues() {
+        let market = &mut test_market();
+        market.market_status = ReadyToClose;
+        market.unclosed_accounts_count = 2;
+
+        let payment_queue = PaymentQueue::new(1);
+        let matching_queue = MatchingQueue::new(1);
+
+        let result = close_market_queues(market, &payment_queue, &matching_queue);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_close_market_queues_incorrect_status() {
+        let market = &mut test_market();
+        market.unclosed_accounts_count = 2;
+
+        let payment_queue = PaymentQueue::new(1);
+        let matching_queue = MatchingQueue::new(1);
+
+        let result = close_market_queues(market, &payment_queue, &matching_queue);
+        assert!(result.is_err());
+        assert_eq!(Err(error!(CoreError::MarketNotReadyToClose)), result);
+    }
+
+    #[test]
+    fn test_close_market_queues_not_empty() {
+        let market = &mut test_market();
+        market.market_status = ReadyToClose;
+        market.unclosed_accounts_count = 2;
+
+        let payment_queue = &mut PaymentQueue::new(1);
+        payment_queue.enqueue(PaymentInfo {
+            to: Pubkey::new_unique(),
+            from: Pubkey::new_unique(),
+            amount: 0,
+        });
+
+        let matching_queue = &mut MatchingQueue::new(1);
+        matching_queue.enqueue(OrderMatched {
+            pk: Pubkey::new_unique(),
+            purchaser: Pubkey::new_unique(),
+            for_outcome: false,
+            outcome_index: 0,
+            price: 0.0,
+            stake: 0,
+        });
+
+        let result = close_market_queues(market, &payment_queue, &matching_queue);
+        assert!(result.is_err());
+        assert_eq!(
+            Err(error!(CoreError::CloseAccountMarketPaymentQueueNotEmpty)),
+            result
+        );
+
+        payment_queue.dequeue();
+
+        let result = close_market_queues(market, &payment_queue, &matching_queue);
+        assert!(result.is_err());
+        assert_eq!(
+            Err(error!(CoreError::CloseAccountMarketMatchingQueueNotEmpty)),
+            result
+        );
+
+        matching_queue.dequeue();
+
+        let result = close_market_queues(market, &payment_queue, &matching_queue);
+        assert!(result.is_ok());
     }
 
     // close order validation
@@ -103,29 +194,19 @@ mod tests {
 
     #[test]
     fn test_close_market() {
-        assert!(close_market(&ReadyToClose, 0, 0).is_ok());
+        assert!(close_market(&ReadyToClose, 0).is_ok());
     }
 
     #[test]
     fn test_close_market_incorrect_status() {
-        let result = close_market(&Open, 0, 0);
+        let result = close_market(&Open, 0);
         assert!(result.is_err());
         assert_eq!(Err(error!(CoreError::MarketNotReadyToClose)), result);
     }
 
     #[test]
-    fn test_close_market_payment_queue_not_empty() {
-        let result = close_market(&ReadyToClose, 1, 0);
-        assert!(result.is_err());
-        assert_eq!(
-            Err(error!(CoreError::CloseAccountMarketPaymentQueueNotEmpty)),
-            result
-        );
-    }
-
-    #[test]
     fn test_close_market_unclosed_accounts() {
-        let result = close_market(&ReadyToClose, 0, 1);
+        let result = close_market(&ReadyToClose, 1);
         assert!(result.is_err());
         assert_eq!(
             Err(error!(CoreError::MarketUnclosedAccountsCountNonZero)),

--- a/programs/monaco_protocol/src/instructions/close.rs
+++ b/programs/monaco_protocol/src/instructions/close.rs
@@ -101,6 +101,7 @@ mod tests {
 
         let result = close_market_queues(market, &payment_queue, &matching_queue);
         assert!(result.is_ok());
+        assert_eq!(market.unclosed_accounts_count, 0);
     }
 
     #[test]
@@ -159,6 +160,7 @@ mod tests {
 
         let result = close_market_queues(market, &payment_queue, &matching_queue);
         assert!(result.is_ok());
+        assert_eq!(market.unclosed_accounts_count, 0);
     }
 
     // close order validation

--- a/programs/monaco_protocol/src/instructions/market/create_market.rs
+++ b/programs/monaco_protocol/src/instructions/market/create_market.rs
@@ -7,10 +7,8 @@ use crate::instructions::current_timestamp;
 use crate::monaco_protocol::{PRICE_SCALE, SEED_SEPARATOR_CHAR};
 use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
 use crate::state::market_matching_pool_account::{Cirque, MarketMatchingPool};
-use crate::state::market_matching_queue_account::{MarketMatchingQueue, MatchingQueue};
 use crate::state::market_outcome_account::MarketOutcome;
 use crate::state::order_account::Order;
-use crate::state::payments_queue::{MarketPaymentsQueue, PaymentQueue};
 use crate::CoreError;
 
 const STATUSES_THAT_SUPPORT_MARKET_RECREATION: [MarketStatus; 2] =
@@ -145,13 +143,6 @@ pub fn create(
         false
     };
 
-    intialize_matching_queue(&mut ctx.accounts.matching_queue, &ctx.accounts.market.key())?;
-
-    intialize_commission_payments_queue(
-        &mut ctx.accounts.commission_payment_queue,
-        &ctx.accounts.market.key(),
-    )?;
-
     Ok(())
 }
 
@@ -237,24 +228,6 @@ pub fn add_prices_to_market_outcome(
         CoreError::MarketPriceListIsFull
     );
 
-    Ok(())
-}
-
-fn intialize_matching_queue(
-    matching_queue: &mut MarketMatchingQueue,
-    market: &Pubkey,
-) -> Result<()> {
-    matching_queue.market = *market;
-    matching_queue.matches = MatchingQueue::new(MarketMatchingQueue::QUEUE_LENGTH);
-    Ok(())
-}
-
-fn intialize_commission_payments_queue(
-    payments_queue: &mut MarketPaymentsQueue,
-    market: &Pubkey,
-) -> Result<()> {
-    payments_queue.market = *market;
-    payments_queue.payment_queue = PaymentQueue::new(MarketPaymentsQueue::QUEUE_LENGTH);
     Ok(())
 }
 

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -310,18 +310,30 @@ mod tests {
             market_lock_order_behaviour: MarketOrderBehaviour::None,
         };
         let matching_queue = &mut MarketMatchingQueue {
-            market: market_pk,
+            market: Pubkey::default(),
             matches: MatchingQueue::new(1),
         };
         let payments_queue = &mut MarketPaymentsQueue {
-            market: market_pk,
+            market: Pubkey::default(),
             payment_queue: PaymentQueue::new(1),
         };
 
         let result = open(&market_pk, &mut market, matching_queue, payments_queue);
 
         assert!(result.is_ok());
-        assert_eq!(MarketStatus::Open, market.market_status)
+        assert_eq!(MarketStatus::Open, market.market_status);
+
+        assert_eq!(matching_queue.market, market_pk);
+        assert_eq!(payments_queue.market, market_pk);
+
+        assert_eq!(
+            matching_queue.matches.size(),
+            MarketMatchingQueue::QUEUE_LENGTH as u32
+        );
+        assert_eq!(
+            payments_queue.payment_queue.size(),
+            MarketPaymentsQueue::QUEUE_LENGTH as u32
+        );
     }
 
     #[test]

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -7,8 +7,15 @@ use solana_program::clock::UnixTimestamp;
 use crate::error::CoreError;
 use crate::state::market_account::Market;
 use crate::state::market_account::MarketStatus::*;
+use crate::state::market_matching_queue_account::{MarketMatchingQueue, MatchingQueue};
+use crate::state::payments_queue::{MarketPaymentsQueue, PaymentQueue};
 
-pub fn open(market: &mut Market) -> Result<()> {
+pub fn open(
+    market_pk: &Pubkey,
+    market: &mut Market,
+    matching_queue: &mut MarketMatchingQueue,
+    commission_payment_queue: &mut MarketPaymentsQueue,
+) -> Result<()> {
     require!(
         Initializing.eq(&market.market_status),
         CoreError::OpenMarketNotInitializing
@@ -17,7 +24,32 @@ pub fn open(market: &mut Market) -> Result<()> {
         market.market_outcomes_count > 1,
         CoreError::OpenMarketNotEnoughOutcomes
     );
+
+    intialize_matching_queue(matching_queue, market_pk)?;
+    market.increment_unclosed_accounts_count()?;
+
+    intialize_commission_payments_queue(commission_payment_queue, market_pk)?;
+    market.increment_unclosed_accounts_count()?;
+
     market.market_status = Open;
+    Ok(())
+}
+
+fn intialize_matching_queue(
+    matching_queue: &mut MarketMatchingQueue,
+    market_pk: &Pubkey,
+) -> Result<()> {
+    matching_queue.market = *market_pk;
+    matching_queue.matches = MatchingQueue::new(MarketMatchingQueue::QUEUE_LENGTH);
+    Ok(())
+}
+
+fn intialize_commission_payments_queue(
+    payments_queue: &mut MarketPaymentsQueue,
+    market_pk: &Pubkey,
+) -> Result<()> {
+    payments_queue.market = *market_pk;
+    payments_queue.payment_queue = PaymentQueue::new(MarketPaymentsQueue::QUEUE_LENGTH);
     Ok(())
 }
 
@@ -26,6 +58,7 @@ pub fn void(market: &mut Market, void_time: UnixTimestamp) -> Result<()> {
         Initializing.eq(&market.market_status) || Open.eq(&market.market_status),
         CoreError::VoidMarketNotInitializingOrOpen
     );
+
     market.market_settle_timestamp = Option::from(void_time);
     market.market_status = ReadyToVoid;
     Ok(())
@@ -123,8 +156,11 @@ mod tests {
     use crate::error::CoreError;
     use crate::instructions::market::{open, settle, void};
     use crate::state::market_account::{MarketOrderBehaviour, MarketStatus};
+    use crate::state::market_matching_queue_account::{MarketMatchingQueue, MatchingQueue};
+    use crate::state::payments_queue::{MarketPaymentsQueue, PaymentQueue};
     use crate::Market;
     use anchor_lang::error;
+    use solana_program::pubkey::Pubkey;
 
     #[test]
     fn settle_market_ok_result() {
@@ -245,6 +281,7 @@ mod tests {
 
     #[test]
     fn open_market_ok_result() {
+        let market_pk = Pubkey::new_unique();
         let mut market = Market {
             authority: Default::default(),
             event_account: Default::default(),
@@ -272,8 +309,16 @@ mod tests {
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
         };
+        let matching_queue = &mut MarketMatchingQueue {
+            market: market_pk,
+            matches: MatchingQueue::new(1),
+        };
+        let payments_queue = &mut MarketPaymentsQueue {
+            market: market_pk,
+            payment_queue: PaymentQueue::new(1),
+        };
 
-        let result = open(&mut market);
+        let result = open(&market_pk, &mut market, matching_queue, payments_queue);
 
         assert!(result.is_ok());
         assert_eq!(MarketStatus::Open, market.market_status)
@@ -281,6 +326,7 @@ mod tests {
 
     #[test]
     fn open_market_not_intializing() {
+        let market_pk = Pubkey::new_unique();
         let mut market = Market {
             authority: Default::default(),
             event_account: Default::default(),
@@ -308,8 +354,16 @@ mod tests {
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
         };
+        let matching_queue = &mut MarketMatchingQueue {
+            market: market_pk,
+            matches: MatchingQueue::new(1),
+        };
+        let payments_queue = &mut MarketPaymentsQueue {
+            market: market_pk,
+            payment_queue: PaymentQueue::new(1),
+        };
 
-        let result = open(&mut market);
+        let result = open(&market_pk, &mut market, matching_queue, payments_queue);
 
         assert!(result.is_err());
         let expected_error = Err(error!(CoreError::OpenMarketNotInitializing));
@@ -318,6 +372,7 @@ mod tests {
 
     #[test]
     fn open_market_not_enough_outcomes() {
+        let market_pk = Pubkey::new_unique();
         let mut market = Market {
             authority: Default::default(),
             event_account: Default::default(),
@@ -345,8 +400,16 @@ mod tests {
             event_start_order_behaviour: MarketOrderBehaviour::None,
             market_lock_order_behaviour: MarketOrderBehaviour::None,
         };
+        let matching_queue = &mut MarketMatchingQueue {
+            market: market_pk,
+            matches: MatchingQueue::new(1),
+        };
+        let payments_queue = &mut MarketPaymentsQueue {
+            market: market_pk,
+            payment_queue: PaymentQueue::new(1),
+        };
 
-        let result = open(&mut market);
+        let result = open(&market_pk, &mut market, matching_queue, payments_queue);
 
         assert!(result.is_err());
         let expected_error = Err(error!(CoreError::OpenMarketNotEnoughOutcomes));

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -415,7 +415,7 @@ pub mod monaco_protocol {
         instructions::market::move_market_to_inplay(market)
     }
 
-    pub fn open_market(ctx: Context<UpdateMarket>) -> Result<()> {
+    pub fn open_market(ctx: Context<OpenMarket>) -> Result<()> {
         verify_operator_authority(
             ctx.accounts.market_operator.key,
             &ctx.accounts.authorised_operators,
@@ -425,7 +425,12 @@ pub mod monaco_protocol {
             &ctx.accounts.market.authority,
         )?;
 
-        instructions::market::open(&mut ctx.accounts.market)
+        instructions::market::open(
+            &ctx.accounts.market.key(),
+            &mut ctx.accounts.market,
+            &mut ctx.accounts.matching_queue,
+            &mut ctx.accounts.commission_payment_queue,
+        )
     }
 
     pub fn settle_market(ctx: Context<UpdateMarket>, winning_outcome_index: u16) -> Result<()> {
@@ -582,10 +587,17 @@ pub mod monaco_protocol {
         instructions::close::close_market_child_account(&mut ctx.accounts.market)
     }
 
+    pub fn close_market_queues(ctx: Context<CloseMarketQueues>) -> Result<()> {
+        instructions::close::close_market_queues(
+            &mut ctx.accounts.market,
+            &ctx.accounts.commission_payment_queue.payment_queue,
+            &ctx.accounts.matching_queue.matches,
+        )
+    }
+
     pub fn close_market(ctx: Context<CloseMarket>) -> Result<()> {
         instructions::close::close_market(
             &ctx.accounts.market.market_status,
-            ctx.accounts.commission_payment_queue.payment_queue.len(),
             ctx.accounts.market.unclosed_accounts_count,
         )?;
 

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -9,6 +9,7 @@ import {
   Orders,
   Trades,
 } from "../../npm-client/src/";
+import console from "console";
 
 describe("End to end test of", () => {
   it("basic lifecycle of inplay market", async () => {
@@ -185,7 +186,7 @@ describe("End to end test of", () => {
     await market.completeSettlement();
     const marketAccount = await market.getAccount();
     assert.equal(marketAccount.unsettledAccountsCount, 0);
-    assert.equal(marketAccount.unclosedAccountsCount, 22);
+    assert.equal(marketAccount.unclosedAccountsCount, 24);
 
     // Close accounts
     await market.readyToClose();
@@ -291,13 +292,22 @@ describe("End to end test of", () => {
       });
 
     await monaco.program.methods
+      .closeMarketQueues()
+      .accounts({
+        market: market.pk,
+        matchingQueue: market.matchingQueuePk,
+        commissionPaymentQueue: market.paymentsQueuePk,
+        authority: monaco.operatorPk,
+      })
+      .rpc()
+      .catch((e) => console.log(e));
+
+    await monaco.program.methods
       .closeMarket()
       .accounts({
         market: market.pk,
         authority: monaco.operatorPk,
         marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
       })
       .rpc()
       .catch((e) => {

--- a/tests/market/recreate_market.ts
+++ b/tests/market/recreate_market.ts
@@ -198,7 +198,6 @@ describe("Recreate markets", () => {
       true,
       false,
     );
-    console.log(JSON.stringify(marketTypeResp, null, 2));
     const marketTypePk = marketTypeResp.data.publicKey;
 
     const existingMarketWrapper = await monaco.createMarketWithOptions({

--- a/tests/protocol/close_market_outcome.ts
+++ b/tests/protocol/close_market_outcome.ts
@@ -18,11 +18,12 @@ describe("Close market outcome accounts", () => {
       marketOperator,
     );
 
+    await market.open();
+
     const balanceOutcomeCreated = await monaco.provider.connection.getBalance(
       marketOperator.publicKey,
     );
 
-    await market.open();
     await market.settle(0);
     await market.completeSettlement();
     await market.readyToClose();

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -17,6 +17,7 @@ describe("Close market accounts (settled)", () => {
       [price],
       marketOperator,
     );
+    await market.open();
 
     const balanceMarketCreated = await monaco.provider.connection.getBalance(
       marketOperator.publicKey,
@@ -27,18 +28,6 @@ describe("Close market accounts (settled)", () => {
     const outcomeBRent = await monaco.provider.connection.getBalance(
       market.outcomePks[0],
     );
-
-    await market.open();
-    await market.settle(0);
-    await market.completeSettlement();
-    await market.readyToClose();
-    await market.closeOutcome(0);
-    await market.closeOutcome(1);
-
-    const marketRent = await monaco.provider.connection.getBalance(market.pk);
-    const escrowRent = await monaco.provider.connection.getBalance(
-      market.escrowPk,
-    );
     const matchingQueueRent = await monaco.provider.connection.getBalance(
       market.matchingQueuePk,
     );
@@ -46,13 +35,23 @@ describe("Close market accounts (settled)", () => {
       market.paymentsQueuePk,
     );
 
+    await market.settle(0);
+    await market.completeSettlement();
+    await market.readyToClose();
+    await market.closeOutcome(0);
+    await market.closeOutcome(1);
+    await market.closeMarketQueues();
+
+    const marketRent = await monaco.provider.connection.getBalance(market.pk);
+    const escrowRent = await monaco.provider.connection.getBalance(
+      market.escrowPk,
+    );
+
     await monaco.program.methods
       .closeMarket()
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })
       .rpc()
@@ -106,19 +105,19 @@ describe("Close market accounts (settled)", () => {
     await market.settle(0);
     await market.completeSettlement();
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: market.pk,
-        marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
-        authority: marketOperator.publicKey,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "MarketNotReadyToClose");
-      });
+    try {
+      await monaco.program.methods
+        .closeMarket()
+        .accounts({
+          market: market.pk,
+          marketEscrow: market.escrowPk,
+          authority: marketOperator.publicKey,
+        })
+        .rpc();
+      assert.fail("MarketNotReadyToClose expected");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "MarketNotReadyToClose");
+    }
   });
 
   it("close market: purchaser mismatch", async () => {
@@ -139,22 +138,22 @@ describe("Close market accounts (settled)", () => {
     await market.completeSettlement();
     await market.readyToClose();
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: market.pk,
-        marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
-        authority: monaco.operatorPk,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
-      });
+    try {
+      await monaco.program.methods
+        .closeMarket()
+        .accounts({
+          market: market.pk,
+          marketEscrow: market.escrowPk,
+          authority: monaco.operatorPk,
+        })
+        .rpc();
+      assert.fail("CloseAccountPurchaserMismatch expected");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+    }
   });
 
-  it("close market: market mismatch", async () => {
+  it("close market queues: market mismatch", async () => {
     const price = 2.0;
     const marketOperator = await createWalletWithBalance(monaco.provider);
     await authoriseMarketOperator(
@@ -186,19 +185,20 @@ describe("Close market accounts (settled)", () => {
     await marketB.closeOutcome(0);
     await marketB.closeOutcome(1);
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: marketB.pk,
-        marketEscrow: marketB.escrowPk,
-        matchingQueue: marketB.matchingQueuePk,
-        commissionPaymentQueue: marketB.paymentsQueuePk,
-        authority: marketOperator.publicKey,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountMarketMismatch");
-      });
+    try {
+      await monaco.program.methods
+        .closeMarketQueues()
+        .accounts({
+          market: marketB.pk,
+          matchingQueue: marketB.matchingQueuePk,
+          commissionPaymentQueue: marketA.paymentsQueuePk,
+          authority: marketOperator.publicKey,
+        })
+        .rpc();
+      assert.fail("CloseAccountMarketMismatch expected");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "CloseAccountMarketMismatch");
+    }
   });
 
   it("close market: unclosed accounts", async () => {
@@ -220,21 +220,21 @@ describe("Close market accounts (settled)", () => {
     await market.readyToClose();
     await market.closeOutcome(0);
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: market.pk,
-        marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
-        authority: marketOperator.publicKey,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(
-          e.error.errorCode.code,
-          "MarketUnclosedAccountsCountNonZero",
-        );
-      });
+    try {
+      await monaco.program.methods
+        .closeMarket()
+        .accounts({
+          market: market.pk,
+          marketEscrow: market.escrowPk,
+          authority: marketOperator.publicKey,
+        })
+        .rpc();
+      assert.fail("MarketUnclosedAccountsCountNonZero expected");
+    } catch (e) {
+      assert.equal(
+        e.error.errorCode.code,
+        "MarketUnclosedAccountsCountNonZero",
+      );
+    }
   });
 });

--- a/tests/protocol/close_market_voided.ts
+++ b/tests/protocol/close_market_voided.ts
@@ -17,6 +17,7 @@ describe("Close market accounts (voided)", () => {
       [price],
       marketOperator,
     );
+    await market.open();
 
     const balanceMarketCreated = await monaco.provider.connection.getBalance(
       marketOperator.publicKey,
@@ -27,18 +28,6 @@ describe("Close market accounts (voided)", () => {
     const outcomeBRent = await monaco.provider.connection.getBalance(
       market.outcomePks[1],
     );
-
-    await market.open();
-    await market.voidMarket();
-    await market.completeVoid();
-    await market.readyToClose();
-    await market.closeOutcome(0);
-    await market.closeOutcome(1);
-
-    const marketRent = await monaco.provider.connection.getBalance(market.pk);
-    const escrowRent = await monaco.provider.connection.getBalance(
-      market.escrowPk,
-    );
     const matchingQueueRent = await monaco.provider.connection.getBalance(
       market.matchingQueuePk,
     );
@@ -46,13 +35,23 @@ describe("Close market accounts (voided)", () => {
       market.paymentsQueuePk,
     );
 
+    await market.voidMarket();
+    await market.completeVoid();
+    await market.readyToClose();
+    await market.closeOutcome(0);
+    await market.closeOutcome(1);
+    await market.closeMarketQueues();
+
+    const marketRent = await monaco.provider.connection.getBalance(market.pk);
+    const escrowRent = await monaco.provider.connection.getBalance(
+      market.escrowPk,
+    );
+
     await monaco.program.methods
       .closeMarket()
       .accounts({
         market: market.pk,
         marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
         authority: marketOperator.publicKey,
       })
       .rpc()
@@ -106,19 +105,19 @@ describe("Close market accounts (voided)", () => {
     await market.voidMarket();
     await market.completeVoid();
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: market.pk,
-        marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
-        authority: marketOperator.publicKey,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "MarketNotReadyToClose");
-      });
+    try {
+      await monaco.program.methods
+        .closeMarket()
+        .accounts({
+          market: market.pk,
+          marketEscrow: market.escrowPk,
+          authority: marketOperator.publicKey,
+        })
+        .rpc();
+      assert.fail("MarketNotReadyToClose expected");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "MarketNotReadyToClose");
+    }
   });
 
   it("close market: purchaser mismatch", async () => {
@@ -139,95 +138,18 @@ describe("Close market accounts (voided)", () => {
     await market.completeVoid();
     await market.readyToClose();
 
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: market.pk,
-        marketEscrow: market.escrowPk,
-        matchingQueue: market.matchingQueuePk,
-        commissionPaymentQueue: market.paymentsQueuePk,
-        authority: monaco.operatorPk,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
-      });
-  });
-
-  it("close market: market mismatch", async () => {
-    const price = 2.0;
-    const marketOperator = await createWalletWithBalance(monaco.provider);
-    await authoriseMarketOperator(
-      monaco.getRawProgram(),
-      marketOperator.publicKey,
-    );
-    const marketA = await monaco.createMarket(
-      ["A", "B"],
-      [price],
-      marketOperator,
-    );
-    const marketB = await monaco.createMarket(
-      ["A", "B"],
-      [price],
-      marketOperator,
-    );
-
-    await marketA.open();
-    await marketA.voidMarket();
-    await marketA.completeVoid();
-    await marketA.readyToClose();
-    await marketA.closeOutcome(0);
-    await marketA.closeOutcome(1);
-
-    await marketB.open();
-    await marketB.voidMarket();
-    await marketB.completeVoid();
-    await marketB.readyToClose();
-    await marketB.closeOutcome(0);
-    await marketB.closeOutcome(1);
-
-    await monaco.program.methods
-      .closeMarket()
-      .accounts({
-        market: marketB.pk,
-        marketEscrow: marketB.escrowPk,
-        matchingQueue: marketB.matchingQueuePk,
-        commissionPaymentQueue: marketB.paymentsQueuePk,
-        authority: marketOperator.publicKey,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountMarketMismatch");
-      });
-  });
-
-  it("complete void: unclosed accounts", async () => {
-    const price = 2.0;
-    const marketOperator = await createWalletWithBalance(monaco.provider);
-    await authoriseMarketOperator(
-      monaco.getRawProgram(),
-      marketOperator.publicKey,
-    );
-    const market = await monaco.createMarket(
-      ["A", "B"],
-      [price],
-      marketOperator,
-    );
-
-    await market.open();
-    await market.voidMarket();
-
-    await monaco.program.methods
-      .completeMarketVoid()
-      .accounts({
-        market: market.pk,
-      })
-      .rpc()
-      .catch((e) => {
-        assert.equal(
-          e.error.errorCode.code,
-          "MarketUnclosedAccountsCountNonZero",
-        );
-      });
+    try {
+      await monaco.program.methods
+        .closeMarket()
+        .accounts({
+          market: market.pk,
+          marketEscrow: market.escrowPk,
+          authority: monaco.operatorPk,
+        })
+        .rpc();
+      assert.fail("CloseAccountPurchaserMismatch expected");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+    }
   });
 });

--- a/tests/util/test_util.ts
+++ b/tests/util/test_util.ts
@@ -273,8 +273,6 @@ export async function createMarket(
       rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       authorisedOperators: authorisedMarketOperators,
       marketOperator: marketOperator.publicKey,
-      matchingQueue: matchingQueuePda,
-      commissionPaymentQueue: commissionPaymentQueuePda,
     })
     .signers([marketOperator])
     .rpc();
@@ -356,10 +354,20 @@ export async function createMarket(
     );
   }
 
+  const matchingQueuePk = (
+    await findMarketMatchingQueuePda(protocolProgram, marketPda)
+  ).data.pda;
+
+  const commissionQueuePk = (
+    await findCommissionPaymentsQueuePda(protocolProgram, marketPda)
+  ).data.pda;
+
   await protocolProgram.methods
     .openMarket()
     .accounts({
       market: marketPda,
+      matchingQueue: matchingQueuePk,
+      commissionPaymentQueue: commissionQueuePk,
       authorisedOperators: authorisedMarketOperators,
       marketOperator: marketOperator.publicKey,
     })


### PR DESCRIPTION
* Create `matching_queue` & `commission_payment_queue` when opening market (rather than market creation)
* Add a new instruction `close_market_queues` to close the above queues (rather than closing using close_market)
* Some test refactoring