### PR TITLE
feat: market liquidities account

### DIFF
--- a/npm-admin-client/docs/endpoints/market_helpers.md
+++ b/npm-admin-client/docs/endpoints/market_helpers.md
@@ -14,21 +14,24 @@
 *   [findEscrowPda][10]
     *   [Parameters][11]
     *   [Examples][12]
-*   [findMarketMatchingQueuePda][13]
+*   [findMarketLiquiditiesPda][13]
     *   [Parameters][14]
     *   [Examples][15]
-*   [findCommissionPaymentsQueuePda][16]
+*   [findMarketMatchingQueuePda][16]
     *   [Parameters][17]
     *   [Examples][18]
-*   [MarketOutcomes][19]
+*   [findCommissionPaymentsQueuePda][19]
     *   [Parameters][20]
     *   [Examples][21]
-*   [getMarketOutcomesByMarket][22]
+*   [MarketOutcomes][22]
     *   [Parameters][23]
     *   [Examples][24]
-*   [getMarketOutcomeTitlesByMarket][25]
+*   [getMarketOutcomesByMarket][25]
     *   [Parameters][26]
     *   [Examples][27]
+*   [getMarketOutcomeTitlesByMarket][28]
+    *   [Parameters][29]
+    *   [Examples][30]
 
 ## findMarketPda
 
@@ -39,10 +42,10 @@ For the provided event publicKey, market type and mint publicKey return a Progra
 *   `program` **Program** {program} anchor program initialized by the consuming client
 *   `eventPk` **PublicKey** {PublicKey} publicKey of an event
 *   `marketTypePk` **PublicKey** {PublicKey} publicKey of the market type
-*   `marketTypeDiscriminator` **([string][28] | null)** {string} discriminator of the market type
-*   `marketTypeValue` **([string][28] | null)** {string} value of the market type
+*   `marketTypeDiscriminator` **([string][31] | null)** {string} discriminator of the market type
+*   `marketTypeValue` **([string][31] | null)** {string} value of the market type
 *   `mintPk` **PublicKey** {PublicKey} publicKey of the currency token
-*   `version` **[number][29]?** {number} (Optional) version of the market, defaults to 0
+*   `version` **[number][32]?** {number} (Optional) version of the market, defaults to 0
 
 ### Examples
 
@@ -110,6 +113,24 @@ const escrowPda = await findEscrowPda(program, marketPK)
 ```
 
 Returns **FindPdaResponse** PDA of the escrow account
+
+## findMarketLiquiditiesPda
+
+For the provided market publicKey, return the PDA (publicKey) of the market liquidities account.
+
+### Parameters
+
+*   `program` **Program** {program} anchor program initialized by the consuming client
+*   `marketPk` **PublicKey** {PublicKey} publicKey of a market
+
+### Examples
+
+```javascript
+const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+const marketLiquiditiesPk = await findMarketLiquiditiesPda(program, marketPK)
+```
+
+Returns **FindPdaResponse** PDA of the market liquidities account
 
 ## findMarketMatchingQueuePda
 
@@ -231,36 +252,42 @@ Returns **MarketOutcomeTitlesResponse** fetched market outcome titles - ordered 
 
 [12]: #examples-3
 
-[13]: #findmarketmatchingqueuepda
+[13]: #findmarketliquiditiespda
 
 [14]: #parameters-4
 
 [15]: #examples-4
 
-[16]: #findcommissionpaymentsqueuepda
+[16]: #findmarketmatchingqueuepda
 
 [17]: #parameters-5
 
 [18]: #examples-5
 
-[19]: #marketoutcomes
+[19]: #findcommissionpaymentsqueuepda
 
 [20]: #parameters-6
 
 [21]: #examples-6
 
-[22]: #getmarketoutcomesbymarket
+[22]: #marketoutcomes
 
 [23]: #parameters-7
 
 [24]: #examples-7
 
-[25]: #getmarketoutcometitlesbymarket
+[25]: #getmarketoutcomesbymarket
 
 [26]: #parameters-8
 
 [27]: #examples-8
 
-[28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[28]: #getmarketoutcometitlesbymarket
 
-[29]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[29]: #parameters-9
+
+[30]: #examples-9
+
+[31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number

--- a/npm-admin-client/src/market_helpers.ts
+++ b/npm-admin-client/src/market_helpers.ts
@@ -169,6 +169,39 @@ export async function findEscrowPda(
 }
 
 /**
+ * For the provided market publicKey, return the PDA (publicKey) of the market liquidities account.
+ *
+ * @param program {program} anchor program initialized by the consuming client
+ * @param marketPk {PublicKey} publicKey of a market
+ * @returns {FindPdaResponse} PDA of the market liquidities account
+ *
+ * @example
+ *
+ * const marketPk = new PublicKey('7o1PXyYZtBBDFZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
+ * const marketLiquiditiesPk = await findMarketLiquiditiesPda(program, marketPK)
+ */
+export async function findMarketLiquiditiesPda(
+  program: Program,
+  marketPk: PublicKey,
+): Promise<ClientResponse<FindPdaResponse>> {
+  const response = new ResponseFactory({} as FindPdaResponse);
+
+  try {
+    const [pda, _] = PublicKey.findProgramAddressSync(
+      [Buffer.from("liquidities"), marketPk.toBuffer()],
+      program.programId,
+    );
+
+    response.addResponseData({
+      pda: pda,
+    });
+  } catch (e) {
+    response.addError(e);
+  }
+  return response.body;
+}
+
+/**
  * For the provided market publicKey, return the PDA (publicKey) of the market matching-queue account.
  *
  * @param program {program} anchor program initialized by the consuming client

--- a/npm-admin-client/src/market_management.ts
+++ b/npm-admin-client/src/market_management.ts
@@ -16,6 +16,7 @@ import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
 import {
   findCommissionPaymentsQueuePda,
   findEscrowPda,
+  findMarketLiquiditiesPda,
   findMarketMatchingQueuePda,
 } from "./market_helpers";
 
@@ -448,6 +449,7 @@ export async function openMarket(
     return response.body;
   }
 
+  const liquidities = await findMarketLiquiditiesPda(program, marketPk);
   const matchingQueue = await findMarketMatchingQueuePda(program, marketPk);
 
   const commissionQueue = await findCommissionPaymentsQueuePda(
@@ -460,6 +462,7 @@ export async function openMarket(
       .openMarket()
       .accounts({
         market: marketPk,
+        liquidities: liquidities.data.pda,
         matchingQueue: matchingQueue.data.pda,
         commissionPaymentQueue: commissionQueue.data.pda,
         authorisedOperators: authorisedOperators.data.pda,

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -709,7 +709,7 @@ pub struct OpenMarket<'info> {
     pub market: Account<'info, Market>,
 
     #[account(
-    init,
+        init,
         seeds = [
             b"liquidities".as_ref(),
             market.key().as_ref(),

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -4,7 +4,8 @@ use anchor_lang::prelude::*;
 pub enum CoreError {
     #[msg("Generic: math operation has failed")]
     ArithmeticError,
-
+    #[msg("MarketOutcome: update failed")]
+    MarketOutcomeUpdateError,
     /*
     Order Creation
      */

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -6,6 +6,7 @@ pub enum CoreError {
     ArithmeticError,
     #[msg("MarketOutcome: update failed")]
     MarketOutcomeUpdateError,
+
     /*
     Order Creation
      */

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -428,6 +428,7 @@ pub mod monaco_protocol {
         instructions::market::open(
             &ctx.accounts.market.key(),
             &mut ctx.accounts.market,
+            &mut ctx.accounts.liquidities,
             &mut ctx.accounts.matching_queue,
             &mut ctx.accounts.commission_payment_queue,
         )
@@ -590,6 +591,7 @@ pub mod monaco_protocol {
     pub fn close_market_queues(ctx: Context<CloseMarketQueues>) -> Result<()> {
         instructions::close::close_market_queues(
             &mut ctx.accounts.market,
+            &ctx.accounts.liquidities,
             &ctx.accounts.commission_payment_queue.payment_queue,
             &ctx.accounts.matching_queue.matches,
         )

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -1,0 +1,417 @@
+use std::cmp::Ordering;
+use std::string::ToString;
+
+use anchor_lang::prelude::*;
+
+use crate::error::CoreError;
+use crate::state::type_size::*;
+
+#[account]
+pub struct MarketLiquidities {
+    pub market: Pubkey,
+    pub liquidities_for: Vec<MarketOutcomePriceLiquidity>,
+    pub liquidities_against: Vec<MarketOutcomePriceLiquidity>,
+}
+
+impl MarketLiquidities {
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE // market
+        + vec_size(18_usize, 0_usize); // liquidities
+
+    pub fn get_liquidity_for(&self, outcome: u16, price: f64) -> MarketOutcomePriceLiquidity {
+        match self
+            .liquidities_for
+            .binary_search_by(Self::sorter_for(outcome, price))
+        {
+            Ok(index) => self.liquidities_for[index],
+            Err(_) => MarketOutcomePriceLiquidity {
+                outcome,
+                price,
+                liquidity: 0,
+            },
+        }
+    }
+
+    pub fn get_liquidity_against(&self, outcome: u16, price: f64) -> MarketOutcomePriceLiquidity {
+        match self
+            .liquidities_against
+            .binary_search_by(Self::sorter_for(outcome, price))
+        {
+            Ok(index) => self.liquidities_for[index],
+            Err(_) => MarketOutcomePriceLiquidity {
+                outcome,
+                price,
+                liquidity: 0,
+            },
+        }
+    }
+
+    pub fn add_liquidity_for(&mut self, outcome: u16, price: f64, liquidity: u64) -> Result<()> {
+        let liquidities = &mut self.liquidities_for;
+        Self::add_liquidity(
+            liquidities,
+            Self::sorter_for(outcome, price),
+            outcome,
+            price,
+            liquidity,
+        )
+    }
+
+    pub fn add_liquidity_against(
+        &mut self,
+        outcome: u16,
+        price: f64,
+        liquidity: u64,
+    ) -> Result<()> {
+        let liquidities = &mut self.liquidities_against;
+        Self::add_liquidity(
+            liquidities,
+            Self::sorter_against(outcome, price),
+            outcome,
+            price,
+            liquidity,
+        )
+    }
+
+    fn add_liquidity(
+        liquidities: &mut Vec<MarketOutcomePriceLiquidity>,
+        search_function: impl FnMut(&MarketOutcomePriceLiquidity) -> Ordering,
+        outcome: u16,
+        price: f64,
+        liquidity: u64,
+    ) -> Result<()> {
+        match liquidities.binary_search_by(search_function) {
+            Ok(index) => {
+                let liquidities_for_value = &mut liquidities[index];
+                liquidities_for_value.liquidity = liquidities_for_value
+                    .liquidity
+                    .checked_add(liquidity)
+                    .ok_or(CoreError::MarketOutcomeUpdateError)?
+            }
+            Err(index) => liquidities.insert(
+                index,
+                MarketOutcomePriceLiquidity {
+                    outcome,
+                    price,
+                    liquidity,
+                },
+            ),
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_liquidity_for(&mut self, outcome: u16, price: f64, liquidity: u64) -> Result<()> {
+        let liquidities = &mut self.liquidities_for;
+        Self::remove_liquidity(liquidities, Self::sorter_for(outcome, price), liquidity)
+    }
+
+    pub fn remove_liquidity_against(
+        &mut self,
+        outcome: u16,
+        price: f64,
+        liquidity: u64,
+    ) -> Result<()> {
+        let liquidities = &mut self.liquidities_against;
+        Self::remove_liquidity(liquidities, Self::sorter_against(outcome, price), liquidity)
+    }
+
+    fn remove_liquidity(
+        liquidities: &mut Vec<MarketOutcomePriceLiquidity>,
+        search_function: impl FnMut(&MarketOutcomePriceLiquidity) -> Ordering,
+        liquidity: u64,
+    ) -> Result<()> {
+        match liquidities.binary_search_by(search_function) {
+            Ok(index) => {
+                let liquidities_for_value = &mut liquidities[index];
+                liquidities_for_value.liquidity = liquidities_for_value
+                    .liquidity
+                    .checked_sub(liquidity)
+                    .ok_or(CoreError::MarketOutcomeUpdateError)?;
+
+                if liquidities_for_value.liquidity == 0 {
+                    liquidities.remove(index);
+                }
+                Ok(())
+            }
+            Err(_) => Err(error!(CoreError::MarketOutcomeUpdateError)),
+        }
+    }
+
+    fn sorter_for(
+        outcome: u16,
+        price: f64,
+    ) -> impl FnMut(&MarketOutcomePriceLiquidity) -> Ordering {
+        move |liquidity| {
+            #[allow(clippy::comparison_chain)]
+            if outcome < liquidity.outcome {
+                return Ordering::Greater;
+            } else if liquidity.outcome < outcome {
+                return Ordering::Less;
+            }
+
+            if price < liquidity.price {
+                return Ordering::Greater;
+            } else if liquidity.price < price {
+                return Ordering::Less;
+            }
+
+            Ordering::Equal
+        }
+    }
+
+    fn sorter_against(
+        outcome: u16,
+        price: f64,
+    ) -> impl FnMut(&MarketOutcomePriceLiquidity) -> Ordering {
+        move |liquidity| {
+            #[allow(clippy::comparison_chain)]
+            if outcome < liquidity.outcome {
+                return Ordering::Less;
+            } else if liquidity.outcome < outcome {
+                return Ordering::Greater;
+            }
+
+            if price < liquidity.price {
+                return Ordering::Less;
+            } else if liquidity.price < price {
+                return Ordering::Greater;
+            }
+
+            Ordering::Equal
+        }
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, Default, PartialEq)]
+pub struct MarketOutcomePriceLiquidity {
+    pub outcome: u16,
+    pub price: f64,
+    pub liquidity: u64,
+}
+
+#[cfg(test)]
+pub fn mock_market_liquidities(market_pk: Pubkey) -> MarketLiquidities {
+    MarketLiquidities {
+        market: market_pk,
+        liquidities_for: Vec::new(),
+        liquidities_against: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod total_exposure_tests {
+    use super::*;
+
+    #[test]
+    fn test_add_liquidity() {
+        let mut market_liquidities: MarketLiquidities = MarketLiquidities {
+            market: Pubkey::default(),
+            liquidities_for: vec![],
+            liquidities_against: vec![],
+        };
+
+        market_liquidities.add_liquidity_for(0, 2.111, 501).unwrap();
+        market_liquidities.add_liquidity_for(0, 2.111, 500).unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 2.111, 2001)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.111, 1500)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(2, 2.111, 1501)
+            .unwrap();
+
+        market_liquidities
+            .add_liquidity_against(0, 2.111, 501)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_against(0, 2.111, 500)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_against(1, 2.111, 2001)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_against(2, 2.111, 1500)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_against(2, 2.111, 1501)
+            .unwrap();
+
+        let expected_for: Vec<MarketOutcomePriceLiquidity> = vec![
+            MarketOutcomePriceLiquidity {
+                outcome: 0,
+                price: 2.111,
+                liquidity: 1001,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 1,
+                price: 2.111,
+                liquidity: 2001,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 2,
+                price: 2.111,
+                liquidity: 3001,
+            },
+        ];
+        assert_eq!(expected_for, market_liquidities.liquidities_for);
+        let expected_against: Vec<MarketOutcomePriceLiquidity> = vec![
+            MarketOutcomePriceLiquidity {
+                outcome: 2,
+                price: 2.111,
+                liquidity: 3001,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 1,
+                price: 2.111,
+                liquidity: 2001,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 0,
+                price: 2.111,
+                liquidity: 1001,
+            },
+        ];
+        assert_eq!(expected_against, market_liquidities.liquidities_against);
+    }
+
+    #[test]
+    fn test_remove_liquidity() {
+        let mut market_liquidities: MarketLiquidities = MarketLiquidities {
+            market: Pubkey::default(),
+            liquidities_for: vec![
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.111,
+                    liquidity: 1001,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 1,
+                    price: 2.111,
+                    liquidity: 2001,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 2,
+                    price: 2.111,
+                    liquidity: 3001,
+                },
+            ],
+            liquidities_against: vec![
+                MarketOutcomePriceLiquidity {
+                    outcome: 2,
+                    price: 2.111,
+                    liquidity: 3001,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 1,
+                    price: 2.111,
+                    liquidity: 2001,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.111,
+                    liquidity: 1001,
+                },
+            ],
+        };
+
+        market_liquidities
+            .remove_liquidity_for(0, 2.111, 200)
+            .unwrap();
+        market_liquidities
+            .remove_liquidity_for(1, 2.111, 200)
+            .unwrap();
+        market_liquidities
+            .remove_liquidity_for(2, 2.111, 200)
+            .unwrap();
+
+        market_liquidities
+            .remove_liquidity_against(0, 2.111, 200)
+            .unwrap();
+        market_liquidities
+            .remove_liquidity_against(1, 2.111, 200)
+            .unwrap();
+        market_liquidities
+            .remove_liquidity_against(2, 2.111, 200)
+            .unwrap();
+
+        let expected_for: Vec<MarketOutcomePriceLiquidity> = vec![
+            MarketOutcomePriceLiquidity {
+                outcome: 0,
+                price: 2.111,
+                liquidity: 801,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 1,
+                price: 2.111,
+                liquidity: 1801,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 2,
+                price: 2.111,
+                liquidity: 2801,
+            },
+        ];
+        assert_eq!(expected_for, market_liquidities.liquidities_for);
+        let expected_against: Vec<MarketOutcomePriceLiquidity> = vec![
+            MarketOutcomePriceLiquidity {
+                outcome: 2,
+                price: 2.111,
+                liquidity: 2801,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 1,
+                price: 2.111,
+                liquidity: 1801,
+            },
+            MarketOutcomePriceLiquidity {
+                outcome: 0,
+                price: 2.111,
+                liquidity: 801,
+            },
+        ];
+        assert_eq!(expected_against, market_liquidities.liquidities_against);
+    }
+
+    #[test]
+    fn test_get_liquidity_for() {
+        let market_liquidities: MarketLiquidities = MarketLiquidities {
+            market: Pubkey::default(),
+            liquidities_for: vec![
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.30,
+                    liquidity: 1001,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.31,
+                    liquidity: 1002,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.32,
+                    liquidity: 1003,
+                },
+                MarketOutcomePriceLiquidity {
+                    outcome: 0,
+                    price: 2.33,
+                    liquidity: 1004,
+                },
+            ],
+            liquidities_against: vec![],
+        };
+
+        assert_eq!(
+            1002,
+            market_liquidities.get_liquidity_for(0, 2.31).liquidity
+        );
+        assert_eq!(0, market_liquidities.get_liquidity_for(0, 2.315).liquidity);
+        assert_eq!(
+            1003,
+            market_liquidities.get_liquidity_for(0, 2.32).liquidity
+        );
+    }
+}

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -16,7 +16,8 @@ pub struct MarketLiquidities {
 impl MarketLiquidities {
     pub const SIZE: usize = DISCRIMINATOR_SIZE
         + PUB_KEY_SIZE // market
-        + vec_size(18_usize, 0_usize); // liquidities
+        + vec_size(18_usize, 0_usize) // liquidities_for
+        + vec_size(18_usize, 0_usize); // liquidities_against
 
     pub fn get_liquidity_for(&self, outcome: u16, price: f64) -> MarketOutcomePriceLiquidity {
         match self

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -205,11 +205,7 @@ mod total_exposure_tests {
 
     #[test]
     fn test_add_liquidity() {
-        let mut market_liquidities: MarketLiquidities = MarketLiquidities {
-            market: Pubkey::default(),
-            liquidities_for: vec![],
-            liquidities_against: vec![],
-        };
+        let mut market_liquidities = mock_market_liquidities(Pubkey::default());
 
         market_liquidities.add_liquidity_for(0, 2.111, 501).unwrap();
         market_liquidities.add_liquidity_for(0, 2.111, 500).unwrap();

--- a/programs/monaco_protocol/src/state/mod.rs
+++ b/programs/monaco_protocol/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod market_account;
+pub(crate) mod market_liquidities;
 pub(crate) mod market_matching_pool_account;
 pub(crate) mod market_matching_queue_account;
 pub(crate) mod market_outcome_account;

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -186,7 +186,7 @@ describe("End to end test of", () => {
     await market.completeSettlement();
     const marketAccount = await market.getAccount();
     assert.equal(marketAccount.unsettledAccountsCount, 0);
-    assert.equal(marketAccount.unclosedAccountsCount, 24);
+    assert.equal(marketAccount.unclosedAccountsCount, 25);
 
     // Close accounts
     await market.readyToClose();
@@ -295,6 +295,7 @@ describe("End to end test of", () => {
       .closeMarketQueues()
       .accounts({
         market: market.pk,
+        liquidities: market.liquiditiesPk,
         matchingQueue: market.matchingQueuePk,
         commissionPaymentQueue: market.paymentsQueuePk,
         authority: monaco.operatorPk,

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -28,6 +28,9 @@ describe("Close market accounts (settled)", () => {
     const outcomeBRent = await monaco.provider.connection.getBalance(
       market.outcomePks[0],
     );
+    const liquiditiesRent = await monaco.provider.connection.getBalance(
+      market.liquiditiesPk,
+    );
     const matchingQueueRent = await monaco.provider.connection.getBalance(
       market.matchingQueuePk,
     );
@@ -65,6 +68,7 @@ describe("Close market accounts (settled)", () => {
       balanceMarketCreated +
       marketRent +
       escrowRent +
+      liquiditiesRent +
       matchingQueueRent +
       paymentsQueueRent +
       outcomeARent +
@@ -190,6 +194,7 @@ describe("Close market accounts (settled)", () => {
         .closeMarketQueues()
         .accounts({
           market: marketB.pk,
+          liquidities: marketB.liquiditiesPk,
           matchingQueue: marketB.matchingQueuePk,
           commissionPaymentQueue: marketA.paymentsQueuePk,
           authority: marketOperator.publicKey,

--- a/tests/protocol/close_market_voided.ts
+++ b/tests/protocol/close_market_voided.ts
@@ -28,6 +28,9 @@ describe("Close market accounts (voided)", () => {
     const outcomeBRent = await monaco.provider.connection.getBalance(
       market.outcomePks[1],
     );
+    const liquiditiesRent = await monaco.provider.connection.getBalance(
+      market.liquiditiesPk,
+    );
     const matchingQueueRent = await monaco.provider.connection.getBalance(
       market.matchingQueuePk,
     );
@@ -65,6 +68,7 @@ describe("Close market accounts (voided)", () => {
       balanceMarketCreated +
       marketRent +
       escrowRent +
+      liquiditiesRent +
       matchingQueueRent +
       paymentsQueueRent +
       outcomeARent +

--- a/tests/util/test_util.ts
+++ b/tests/util/test_util.ts
@@ -42,6 +42,7 @@ import console from "console";
 import * as idl from "../anchor/protocol_product/protocol_product.json";
 import {
   findCommissionPaymentsQueuePda,
+  findMarketLiquiditiesPda,
   findMarketMatchingQueuePda,
   PaymentInfo,
 } from "../../npm-admin-client";
@@ -354,6 +355,10 @@ export async function createMarket(
     );
   }
 
+  const liquiditiesPk = (
+    await findMarketLiquiditiesPda(protocolProgram, marketPda)
+  ).data.pda;
+
   const matchingQueuePk = (
     await findMarketMatchingQueuePda(protocolProgram, marketPda)
   ).data.pda;
@@ -366,6 +371,7 @@ export async function createMarket(
     .openMarket()
     .accounts({
       market: marketPda,
+      liquidities: liquiditiesPk,
       matchingQueue: matchingQueuePk,
       commissionPaymentQueue: commissionQueuePk,
       authorisedOperators: authorisedMarketOperators,

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -32,6 +32,7 @@ import { findAuthorisedOperatorsPda, findProductPda } from "../util/pdas";
 import { ProtocolProduct } from "../anchor/protocol_product/protocol_product";
 import {
   createPriceLadderWithPrices,
+  findMarketLiquiditiesPda,
   findCommissionPaymentsQueuePda,
   findMarketMatchingQueuePda,
   findPriceLadderPda,
@@ -458,6 +459,11 @@ export class Monaco {
       }),
     );
 
+    const liquiditiesPk = await findMarketLiquiditiesPda(
+      this.program as Program,
+      marketPk,
+    );
+
     const matchingQueuePk = await findMarketMatchingQueuePda(
       this.program as Program,
       marketPk,
@@ -473,6 +479,7 @@ export class Monaco {
       externalPrograms,
       marketPk,
       marketEscrowPk.data.pda,
+      liquiditiesPk.data.pda,
       matchingQueuePk.data.pda,
       commissionQueuePk.data.pda,
       outcomePks,
@@ -533,6 +540,7 @@ export class MonacoMarket {
   private externalPrograms: ExternalPrograms;
   readonly pk: PublicKey;
   readonly escrowPk: PublicKey;
+  readonly liquiditiesPk: PublicKey;
   readonly matchingQueuePk: PublicKey;
   readonly paymentsQueuePk: PublicKey;
   readonly outcomePks: PublicKey[];
@@ -558,6 +566,7 @@ export class MonacoMarket {
     externalPrograms: ExternalPrograms,
     pk: PublicKey,
     escrowPk: PublicKey,
+    liquiditiesPk: PublicKey,
     matchingQueuePk: PublicKey,
     paymentsQueuePk: PublicKey,
     outcomePks: PublicKey[],
@@ -575,6 +584,7 @@ export class MonacoMarket {
     this.externalPrograms = externalPrograms;
     this.pk = pk;
     this.escrowPk = escrowPk;
+    this.liquiditiesPk = liquiditiesPk;
     this.matchingQueuePk = matchingQueuePk;
     this.paymentsQueuePk = paymentsQueuePk;
     this.outcomePks = outcomePks;
@@ -1030,6 +1040,7 @@ export class MonacoMarket {
       .openMarket()
       .accounts({
         market: this.pk,
+        liquidities: this.liquiditiesPk,
         matchingQueue: this.matchingQueuePk,
         commissionPaymentQueue: this.paymentsQueuePk,
         authorisedOperators:
@@ -1169,6 +1180,7 @@ export class MonacoMarket {
       .closeMarketQueues()
       .accounts({
         market: this.pk,
+        liquidities: this.liquiditiesPk,
         matchingQueue: this.matchingQueuePk,
         commissionPaymentQueue: this.paymentsQueuePk,
         authority: this.marketAuthority.publicKey,


### PR DESCRIPTION
Second account needed to deliver improved matching. This account holds summary of the unmatched liquidity available on the market.