### PR TITLE
hotfix: 0.12.1 void order status check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Current version of the protocol on mainnet-beta: [0.11.0](https://github.com/Mon
 
 | Date       | Protocol version                                                          | Program address                               |
 |------------|---------------------------------------------------------------------------|-----------------------------------------------|
+| TBC        | [0.12.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.12.1) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
 | TBC        | [0.12.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.12.0) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
 | 2023-08-01 | [0.11.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.11.0) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
 | 2023-07-06 | [0.10.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.1) | `monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih` |
@@ -40,6 +41,7 @@ Protocol releases, along with their corresponding client versions and audit repo
 
 | Protocol version                                                          | Client       | Admin client | Audit reports                                                                      |
 |---------------------------------------------------------------------------|--------------|--------------|------------------------------------------------------------------------------------|
+| [0.12.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.12.1) | 9.0.0        | 8.0.0        |  |
 | [0.12.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.12.0) | 9.0.0        | 8.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.12.0.pdf) |
 | [0.11.0](https://github.com/MonacoProtocol/protocol/releases/tag/v0.11.0) | 8.0.0        | 7.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.11.0.pdf) |
 | [0.10.1](https://github.com/MonacoProtocol/protocol/releases/tag/v0.10.1) | 7.1.0        | 6.0.0        | [Sec3](https://github.com/MonacoProtocol/protocol/tree/main/audit/sec3/0.10.1.pdf) |

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.12.0"
+version = "0.12.1"
 description = "Created with Anchor"
 edition = "2018"
 

--- a/programs/monaco_protocol/src/instructions/order/void_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/void_order.rs
@@ -4,7 +4,7 @@ use crate::error::CoreError;
 use crate::state::market_account::{Market, MarketStatus};
 use crate::state::order_account::*;
 
-pub fn void_order(order: &mut Account<Order>, market: &mut Account<Market>) -> Result<()> {
+pub fn void_order(order: &mut Order, market: &mut Market) -> Result<()> {
     require!(
         market.market_status.eq(&MarketStatus::ReadyToVoid),
         CoreError::VoidMarketNotReadyForVoid
@@ -14,11 +14,158 @@ pub fn void_order(order: &mut Account<Order>, market: &mut Account<Market>) -> R
         CoreError::VoidOrderIsVoided
     );
 
-    order.order_status = OrderStatus::Voided;
-    order.voided_stake = order.stake;
-    order.stake_unmatched = 0_u64;
+    if !OrderStatus::Cancelled.eq(&order.order_status) {
+        order.voided_stake = order.stake;
+        order.stake_unmatched = 0_u64;
+        market.decrement_unsettled_accounts_count()?;
+    }
 
-    market.decrement_unsettled_accounts_count()?;
+    order.order_status = OrderStatus::Voided;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::market_account::MarketOrderBehaviour;
+
+    #[test]
+    fn test_void_open_order() {
+        let mut order = mock_order();
+        let mut market = mock_market();
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_ok());
+        assert_eq!(order.order_status, OrderStatus::Voided);
+        assert_eq!(order.voided_stake, order.stake);
+        assert_eq!(order.stake_unmatched, 0);
+        assert_eq!(market.unsettled_accounts_count, 0);
+    }
+
+    #[test]
+    fn test_void_matched_order() {
+        let mut order = mock_order();
+        order.order_status = OrderStatus::Matched;
+        order.stake_unmatched = 5;
+        let mut market = mock_market();
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_ok());
+        assert_eq!(order.order_status, OrderStatus::Voided);
+        assert_eq!(order.voided_stake, order.stake);
+        assert_eq!(order.stake_unmatched, 0);
+        assert_eq!(market.unsettled_accounts_count, 0);
+    }
+
+    #[test]
+    fn test_void_cancelled_order() {
+        let mut order = mock_order();
+        order.order_status = OrderStatus::Cancelled;
+        order.voided_stake = order.stake;
+        order.stake_unmatched = 0;
+        let mut market = mock_market();
+        market.unsettled_accounts_count = 0;
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_ok());
+        assert_eq!(order.order_status, OrderStatus::Voided);
+        assert_eq!(order.voided_stake, order.stake);
+        assert_eq!(order.stake_unmatched, 0);
+        assert_eq!(market.unsettled_accounts_count, 0);
+    }
+
+    #[test]
+    fn test_void_voided_order() {
+        let mut order = mock_order();
+        order.order_status = OrderStatus::Voided;
+        order.voided_stake = order.stake;
+        let mut market = mock_market();
+        market.unsettled_accounts_count = 0;
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), error!(CoreError::VoidOrderIsVoided));
+    }
+
+    #[test]
+    fn test_void_market_already_voided() {
+        let mut order = mock_order();
+        order.order_status = OrderStatus::Voided;
+        let mut market = mock_market();
+        market.market_status = MarketStatus::Voided;
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            error!(CoreError::VoidMarketNotReadyForVoid)
+        );
+    }
+
+    #[test]
+    fn test_void_market_already_settled() {
+        let mut order = mock_order();
+        order.order_status = OrderStatus::SettledWin;
+        let mut market = mock_market();
+        market.market_status = MarketStatus::Settled;
+
+        let result = void_order(&mut order, &mut market);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            error!(CoreError::VoidMarketNotReadyForVoid)
+        );
+    }
+
+    fn mock_order() -> Order {
+        Order {
+            order_status: OrderStatus::Open,
+            stake: 10,
+            stake_unmatched: 10,
+            voided_stake: 0,
+
+            purchaser: Default::default(),
+            market: Default::default(),
+            market_outcome_index: 0,
+            for_outcome: false,
+            product: None,
+            payout: 0,
+            payer: Default::default(),
+            expected_price: 0.0,
+            creation_timestamp: 0,
+            delay_expiration_timestamp: 0,
+            product_commission_rate: 0.0,
+        }
+    }
+    fn mock_market() -> Market {
+        Market {
+            unsettled_accounts_count: 1,
+            market_status: MarketStatus::ReadyToVoid,
+
+            authority: Default::default(),
+            event_account: Default::default(),
+            mint_account: Default::default(),
+            inplay_enabled: false,
+            inplay: false,
+            market_type: Default::default(),
+            market_type_discriminator: None,
+            market_type_value: None,
+            version: 0,
+            decimal_limit: 0,
+            published: false,
+            suspended: false,
+            market_outcomes_count: 0,
+            market_winning_outcome_index: None,
+            market_lock_timestamp: 0,
+            market_settle_timestamp: None,
+            event_start_order_behaviour: MarketOrderBehaviour::None,
+            market_lock_order_behaviour: MarketOrderBehaviour::None,
+            inplay_order_delay: 0,
+            title: "".to_string(),
+            unclosed_accounts_count: 0,
+            escrow_account_bump: 0,
+            event_start_timestamp: 0,
+        }
+    }
 }

--- a/tests/protocol/void_order.ts
+++ b/tests/protocol/void_order.ts
@@ -48,25 +48,4 @@ describe("Void order", () => {
       assert.equal(e.error.errorCode.code, "VoidMarketNotReadyForVoid");
     }
   });
-
-  it("order already voided", async () => {
-    const price = 2.0;
-    const [purchaser, market] = await Promise.all([
-      createWalletWithBalance(monaco.provider),
-      monaco.create3WayMarket([price]),
-    ]);
-    await market.airdrop(purchaser, 100.0);
-
-    const forOrderPk = await market.forOrder(0, 10.0, price, purchaser);
-
-    await market.voidMarket();
-    await market.voidOrder(forOrderPk);
-
-    try {
-      await market.voidOrder(forOrderPk);
-      assert.fail("expected VoidOrderIsVoided");
-    } catch (e) {
-      assert.equal(e.error.errorCode.code, "VoidOrderIsVoided");
-    }
-  });
 });


### PR DESCRIPTION
When orders are cancelled in certain cases and are kept open with their status updated to `Cancelled` the market `settled_account_count` is decremented. If that market is subsequently voided, then `void_order` incorrectly also decrements `settled_account_count` for those orders. This can result in the `settled_account_count` prematurely reaching `0` and preventing market voiding from completing completely. 

This fix corrects `void_order`, preventing `Cancelled` orders from affecting the  market's `settled_account_count` during voiding. 

This issue was introduced in 0.12.0.  Correct handling of `Cancelled` orders was added to order settlement, but was missed from order voiding.