### PR TITLE
chore: dependency bump and audit fixes for release 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,8 +1558,8 @@ dependencies = [
 
 [[package]]
 name = "protocol_product"
-version = "0.1.0"
-source = "git+https://github.com/BetDexLabs/protocol-product?rev=aa95db781e06774783b8bcf8f914ebe67c0d77ac#aa95db781e06774783b8bcf8f914ebe67c0d77ac"
+version = "0.2.0"
+source = "git+https://github.com/MonacoProtocol/protocol-product?rev=v0.2.0#10b312aa6db7402f31f6fcf5324379196ee85a31"
 dependencies = [
  "anchor-lang",
  "rust_decimal",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -24,4 +24,4 @@ anchor-spl = "0.29.0"
 spl-token = "4.0.0"
 rust_decimal = "1.32.0"
 test-case = "3.2.1"
-protocol_product = { git = "https://github.com/BetDexLabs/protocol-product", rev = "aa95db781e06774783b8bcf8f914ebe67c0d77ac", features = ["no-entrypoint"] }
+protocol_product = { git = "https://github.com/MonacoProtocol/protocol-product", rev = "v0.2.0", features = ["no-entrypoint"] }

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -277,6 +277,8 @@ pub enum CoreError {
      */
     #[msg("CloseAccount: Order not complete")]
     CloseAccountOrderNotComplete,
+    #[msg("CloseAccount: MarketPosition not paid")]
+    CloseAccountMarketPositionNotPaid,
     #[msg("CloseAccount: Purchaser does not match")]
     CloseAccountPurchaserMismatch,
     #[msg("CloseAccount: Payer does not match")]

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -571,7 +571,10 @@ pub mod monaco_protocol {
     }
 
     pub fn close_market_position(ctx: Context<CloseMarketPosition>) -> Result<()> {
-        instructions::close::close_market_child_account(&mut ctx.accounts.market)
+        instructions::close::close_market_position(
+            &mut ctx.accounts.market,
+            &ctx.accounts.market_position,
+        )
     }
 
     pub fn close_market_matching_pool(ctx: Context<CloseMarketMatchingPool>) -> Result<()> {


### PR DESCRIPTION
This updates 0.13.0 with 
* a dependency bump for the Protocol Product program, now targeting the audited v0.2.0 release which includes the upgrade to anchor 0.29.0
* An improvement for settlement of orders and market positions to keep market state checks consistent for the different settlement instructions
* An improvement to closure of market positions during market closure, giving better protection from bugs affecting the market status and/or market settled_account_counts, reducing the likelihood of ever closing a market position before it has been paid out.