### PR TITLE
chore: removing a deprecated test helper method

### DIFF
--- a/npm-client/docs/endpoints/cancel_order_instruction.md
+++ b/npm-client/docs/endpoints/cancel_order_instruction.md
@@ -17,7 +17,7 @@ Constructs the instruction required to perform a cancel order transaction.
 
 *   `program` **Program** {program} anchor program initialized by the consuming client
 *   `orderPk` **PublicKey** {PublicKey} publicKey of the order to cancel
-*   `mintPk` **PublicKey?**&#x20;
+*   `mintPk` **PublicKey?** {PublicKey} Optional: publicKey of the mint account used for market entry (e.g. USDT), if not provided the market token account will be fetched from the market
 
 ### Examples
 

--- a/npm-client/src/cancel_order_instruction.ts
+++ b/npm-client/src/cancel_order_instruction.ts
@@ -21,6 +21,7 @@ import { getCancellableOrdersByMarketForProviderWallet } from "./order_query";
  *
  * @param program {program} anchor program initialized by the consuming client
  * @param orderPk {PublicKey} publicKey of the order to cancel
+ * @param mintPk {PublicKey} Optional: publicKey of the mint account used for market entry (e.g. USDT), if not provided the market token account will be fetched from the market
  * @returns {OrderInstructionResponse} provided order publicKey and the instruction to perform a cancel order transaction
  *
  * @example

--- a/tests/order/cancelation_payment_10.ts
+++ b/tests/order/cancelation_payment_10.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { cancelOrderSmart, createWalletWithBalance } from "../util/test_util";
+import { createWalletWithBalance } from "../util/test_util";
 import { monaco } from "../util/wrappers";
 
 /*
@@ -69,7 +69,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel Against 5
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -89,7 +89,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -152,7 +152,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -172,7 +172,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel Against 5
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -232,7 +232,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel Against 5
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -252,7 +252,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -312,7 +312,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -332,7 +332,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel Against 5
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([

--- a/tests/order/cancelation_payment_11.ts
+++ b/tests/order/cancelation_payment_11.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { cancelOrderSmart, createWalletWithBalance } from "../util/test_util";
+import { createWalletWithBalance } from "../util/test_util";
 import { monaco } from "../util/wrappers";
 
 /*
@@ -97,7 +97,7 @@ describe("Order Cancelation Payment 11", () => {
     );
 
     // Cancel partially matched against order
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -189,7 +189,7 @@ describe("Order Cancelation Payment 11", () => {
     );
 
     // Cancel partially matched against order
-    await cancelOrderSmart(againstOrderPk, purchaser);
+    await market.cancel(againstOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -281,7 +281,7 @@ describe("Order Cancelation Payment 11", () => {
     );
 
     // Cancel partially matched for order
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -373,7 +373,7 @@ describe("Order Cancelation Payment 11", () => {
     );
 
     // Cancel partially matched for order
-    await cancelOrderSmart(forOrderPk, purchaser);
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([


### PR DESCRIPTION
Removing an old helper method `cancelOrderSmart` that was superseded by simpler wrapper `cancel` method.