### PR TITLE
fix: check payments queue on completeSettlement

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -923,6 +923,14 @@ pub struct SetMarketReadyToClose<'info> {
 pub struct CompleteMarketSettlement<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
+    #[account(has_one = market @ CoreError::SettlementMarketMismatch)]
+    pub commission_payments_queue: Account<'info, MarketPaymentsQueue>,
+}
+
+#[derive(Accounts)]
+pub struct CompleteMarketVoid<'info> {
+    #[account(mut)]
+    pub market: Account<'info, Market>,
 }
 
 #[derive(Accounts)]

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -85,6 +85,8 @@ pub enum CoreError {
     SettlementMarketEscrowNonZero,
     #[msg("Core Settlement: market matching queue not empty")]
     SettlementMarketMatchingQueueNotEmpty,
+    #[msg("Core Settlement: market payment queue not empty")]
+    SettlementMarketPaymentsQueueNotEmpty,
     #[msg("Core Settlement: error calculating settlement payment.")]
     SettlementPaymentCalculation,
     #[msg("Core Settlement: failed to enqueue payment - queue full.")]

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -507,7 +507,10 @@ pub mod monaco_protocol {
     }
 
     pub fn complete_market_settlement(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
-        instructions::market::complete_settlement(ctx)
+        instructions::market::complete_settlement(
+            &mut ctx.accounts.market,
+            &ctx.accounts.commission_payments_queue,
+        )
     }
 
     pub fn void_market(ctx: Context<VoidMarket>) -> Result<()> {
@@ -531,8 +534,8 @@ pub mod monaco_protocol {
         )
     }
 
-    pub fn complete_market_void(ctx: Context<CompleteMarketSettlement>) -> Result<()> {
-        instructions::market::complete_void(ctx)
+    pub fn complete_market_void(ctx: Context<CompleteMarketVoid>) -> Result<()> {
+        instructions::market::complete_void(&mut ctx.accounts.market)
     }
 
     pub fn publish_market(ctx: Context<UpdateMarket>) -> Result<()> {

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -150,9 +150,8 @@ pub enum MarketOrderBehaviour {
 
 #[cfg(test)]
 mod tests {
+    use crate::state::market_account::{mock_market, Market, MarketOrderBehaviour, MarketStatus};
     use anchor_lang::prelude::*;
-
-    use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     // Market account tests
@@ -309,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_increment_unsettled_accounts_count() {
-        let mut market = test_market();
+        let mut market = mock_market(MarketStatus::Initializing);
 
         let result = market.increment_unsettled_accounts_count();
         assert!(result.is_ok());
@@ -322,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_decrement_unsettled_accounts_count() {
-        let mut market = test_market();
+        let mut market = mock_market(MarketStatus::Initializing);
 
         let result = market.increment_unsettled_accounts_count();
         assert!(result.is_ok());
@@ -335,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_increment_unclosed_accounts_count() {
-        let mut market = test_market();
+        let mut market = mock_market(MarketStatus::Initializing);
 
         let result = market.increment_unclosed_accounts_count();
         assert!(result.is_ok());
@@ -348,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_decrement_unclosed_accounts_count() {
-        let mut market = test_market();
+        let mut market = mock_market(MarketStatus::Initializing);
 
         let result = market.increment_unclosed_accounts_count();
         assert!(result.is_ok());
@@ -358,34 +357,35 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(0, market.unclosed_accounts_count);
     }
+}
 
-    fn test_market() -> Market {
-        Market {
-            authority: Default::default(),
-            event_account: Default::default(),
-            mint_account: Default::default(),
-            market_status: MarketStatus::Initializing,
-            inplay_enabled: false,
-            inplay: false,
-            market_type: Default::default(),
-            market_type_discriminator: None,
-            market_type_value: None,
-            version: 0,
-            decimal_limit: 0,
-            published: false,
-            suspended: false,
-            market_outcomes_count: 0,
-            market_winning_outcome_index: None,
-            market_lock_timestamp: 0,
-            market_settle_timestamp: None,
-            event_start_order_behaviour: MarketOrderBehaviour::None,
-            market_lock_order_behaviour: MarketOrderBehaviour::None,
-            inplay_order_delay: 0,
-            title: "".to_string(),
-            unsettled_accounts_count: 0,
-            unclosed_accounts_count: 0,
-            escrow_account_bump: 0,
-            event_start_timestamp: 0,
-        }
+#[cfg(test)]
+pub fn mock_market(market_status: MarketStatus) -> Market {
+    Market {
+        market_status,
+        authority: Default::default(),
+        event_account: Default::default(),
+        mint_account: Default::default(),
+        inplay_enabled: false,
+        inplay: false,
+        market_type: Default::default(),
+        market_type_discriminator: None,
+        market_type_value: None,
+        version: 0,
+        decimal_limit: 0,
+        published: false,
+        suspended: false,
+        market_outcomes_count: 0,
+        market_winning_outcome_index: None,
+        market_lock_timestamp: 0,
+        market_settle_timestamp: None,
+        event_start_order_behaviour: MarketOrderBehaviour::None,
+        market_lock_order_behaviour: MarketOrderBehaviour::None,
+        inplay_order_delay: 0,
+        title: "".to_string(),
+        unsettled_accounts_count: 0,
+        unclosed_accounts_count: 0,
+        escrow_account_bump: 0,
+        event_start_timestamp: 0,
     }
 }

--- a/programs/monaco_protocol/src/state/payments_queue.rs
+++ b/programs/monaco_protocol/src/state/payments_queue.rs
@@ -99,6 +99,14 @@ impl PaymentQueue {
 }
 
 #[cfg(test)]
+pub fn mock_market_payments_queue(market_pk: Pubkey) -> MarketPaymentsQueue {
+    MarketPaymentsQueue {
+        market: market_pk,
+        payment_queue: PaymentQueue::new(MarketPaymentsQueue::QUEUE_LENGTH),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1295,6 +1295,7 @@ export class MonacoMarket {
       .completeMarketSettlement()
       .accounts({
         market: this.pk,
+        commissionPaymentsQueue: this.paymentsQueuePk,
       })
       .rpc()
       .catch((e) => {


### PR DESCRIPTION
 Settlement shouldn't be called "complete" until all payouts, and commission payments are complete. The check that the unsettled account count is 0 ensures that payouts are complete. To ensure that the commission payments are complete the queue must be passed in and checked that it is empty. 

Also refactored a few unit tests when adding a `mock_market` test helper to `market_account.rs`, and adding some new tests to cover `complete_settlement`. 