### PR TITLE
chore: updating peek and adding peek_mut methods

### DIFF
--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -78,15 +78,6 @@ impl Cirque {
         self.capacity
     }
 
-    pub fn peek(&mut self, index: u32) -> Option<&Pubkey> {
-        if index >= self.len {
-            None
-        } else {
-            let capacity = self.capacity();
-            Some(&self.items[((self.front + index) % capacity) as usize])
-        }
-    }
-
     fn back(&self) -> u32 {
         // #[soteria(ignore)] 0 <= front < capacity() AND 0 <= len < capacity() AND capacity() == QUEUE_LENGTH << u32::MAX
         (self.front + self.len) % self.capacity()
@@ -94,6 +85,15 @@ impl Cirque {
 
     pub fn set_length_to_zero(&mut self) {
         self.len = 0
+    }
+
+    pub fn peek(&self, index: u32) -> Option<&Pubkey> {
+        if index >= self.len {
+            None
+        } else {
+            let items_index = ((self.front + index) % self.capacity()) as usize;
+            Some(&self.items[items_index])
+        }
     }
 
     pub fn enqueue(&mut self, item: Pubkey) -> Option<u32> {

--- a/programs/monaco_protocol/src/state/market_matching_queue_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_queue_account.rs
@@ -55,7 +55,15 @@ impl MatchingQueue {
         (self.front + self.len) % self.size()
     }
 
-    pub fn peek(&mut self) -> Option<&mut OrderMatched> {
+    pub fn peek(&self) -> Option<&OrderMatched> {
+        if self.len == 0 {
+            None
+        } else {
+            Some(&self.items[self.front as usize])
+        }
+    }
+
+    pub fn peek_mut(&mut self) -> Option<&mut OrderMatched> {
         if self.len == 0 {
             None
         } else {
@@ -211,6 +219,10 @@ mod tests_matching_queue {
         let result = queue.peek();
         assert!(result.is_none());
         assert_eq!(0, queue.len());
+
+        let result_mut = queue.peek_mut();
+        assert!(result_mut.is_none());
+        assert_eq!(0, queue.len());
     }
 
     #[test]
@@ -224,6 +236,11 @@ mod tests_matching_queue {
         assert!(result.is_some());
         assert_eq!(item, *result.unwrap());
         assert_eq!(1, queue.len());
+
+        let result_mut = queue.peek_mut();
+        assert!(result_mut.is_some());
+        assert_eq!(item, *result_mut.unwrap());
+        assert_eq!(1, queue.len());
     }
 
     #[test]
@@ -233,8 +250,7 @@ mod tests_matching_queue {
         queue.enqueue(OrderMatched::default());
         assert_eq!(2, queue.len());
 
-        let result0 = queue.peek().unwrap();
-        result0.stake = 10;
-        assert_eq!(10, queue.items[0].stake);
+        queue.peek_mut().unwrap().stake = 10;
+        assert_eq!(10, queue.peek().unwrap().stake);
     }
 }


### PR DESCRIPTION
matching pool: peek should not need to have self mutable
matching queue: peek should not need to have self mutable, however mutable version is needed so creating two versions of the method