### PR TITLE
fix: ensure fee payer (if custom) is refunded when accounts are closed

### DIFF
--- a/npm-client/src/cancel_order_instruction.ts
+++ b/npm-client/src/cancel_order_instruction.ts
@@ -87,6 +87,7 @@ export async function buildCancelOrderInstruction(
       marketPosition: marketPositionPda.data.pda,
       purchaser: provider.wallet.publicKey,
       purchaserTokenAccount: purchaserTokenAccount.data.associatedTokenAccount,
+      payer: order.payer,
       marketMatchingPool: marketMatchingPoolPda.data.pda,
       marketOutcome: marketOutcomePda.data.pda,
       market: order.market,
@@ -176,6 +177,7 @@ export async function buildCancelOrdersForMarketInstructions(
           purchaser: provider.wallet.publicKey,
           purchaserTokenAccount:
             purchaserTokenAccount.data.associatedTokenAccount,
+          payer: order.account.payer,
           marketMatchingPool: marketMatchingPoolPda.data.pda,
           marketOutcome: marketOutcomePda.data.pda,
           market: order.account.market,

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -257,6 +257,9 @@ pub struct CancelOrder<'info> {
     )]
     pub purchaser_token_account: Account<'info, TokenAccount>,
 
+    #[account(mut, address = order.payer @ CoreError::CancelationPayerMismatch)]
+    pub payer: SystemAccount<'info>,
+
     #[account(mut, address = order.market @ CoreError::CancelationMarketMismatch)]
     pub market: Account<'info, Market>,
     #[account(
@@ -695,8 +698,8 @@ pub struct MatchOrders<'info> {
 pub struct SettleOrder<'info> {
     #[account(mut)]
     pub order: Account<'info, Order>,
-    #[account(mut, address = order.purchaser @ CoreError::SettlementPurchaserMismatch)]
-    pub purchaser: SystemAccount<'info>,
+    #[account(mut, address = order.payer @ CoreError::SettlementPayerMismatch)]
+    pub payer: SystemAccount<'info>,
     #[account(mut, address = order.market @ CoreError::SettlementMarketMismatch)]
     pub market: Box<Account<'info, Market>>,
 }
@@ -1174,22 +1177,22 @@ Close accounts
 pub struct CloseOrder<'info> {
     #[account(
         mut,
-        has_one = purchaser @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = payer @ CoreError::CloseAccountPayerMismatch,
         has_one = market @ CoreError::CloseAccountMarketMismatch,
-        close = purchaser,
+        close = payer,
     )]
     pub order: Account<'info, Order>,
     #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
-    pub purchaser: SystemAccount<'info>,
+    pub payer: SystemAccount<'info>,
 }
 
 #[derive(Accounts)]
 pub struct CloseTrade<'info> {
     #[account(
         mut,
-        has_one = payer @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = payer @ CoreError::CloseAccountPayerMismatch,
         has_one = market @ CoreError::CloseAccountMarketMismatch,
         close = payer,
     )]
@@ -1204,15 +1207,15 @@ pub struct CloseTrade<'info> {
 pub struct CloseMarketPosition<'info> {
     #[account(
         mut,
-        has_one = purchaser @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = payer @ CoreError::CloseAccountPayerMismatch,
         has_one = market @ CoreError::CloseAccountMarketMismatch,
-        close = purchaser,
+        close = payer,
     )]
     pub market_position: Account<'info, MarketPosition>,
     #[account(mut)]
     pub market: Account<'info, Market>,
     #[account(mut)]
-    pub purchaser: SystemAccount<'info>,
+    pub payer: SystemAccount<'info>,
 }
 
 #[derive(Accounts)]
@@ -1240,7 +1243,7 @@ pub struct CloseMarketOutcome<'info> {
     pub market_outcome: Account<'info, MarketOutcome>,
     #[account(
         mut,
-        has_one = authority @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = authority @ CoreError::CloseAccountMarketAuthorityMismatch,
     )]
     pub market: Account<'info, Market>,
     #[account(mut)]
@@ -1275,7 +1278,7 @@ pub struct CloseMarketQueues<'info> {
     pub order_request_queue: Account<'info, MarketOrderRequestQueue>,
     #[account(
         mut,
-        has_one = authority @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = authority @ CoreError::CloseAccountMarketAuthorityMismatch,
     )]
     pub market: Account<'info, Market>,
     #[account(mut)]
@@ -1286,7 +1289,7 @@ pub struct CloseMarketQueues<'info> {
 pub struct CloseMarket<'info> {
     #[account(
         mut,
-        has_one = authority @ CoreError::CloseAccountPurchaserMismatch,
+        has_one = authority @ CoreError::CloseAccountMarketAuthorityMismatch,
         close = authority,
     )]
     pub market: Account<'info, Market>,

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -53,6 +53,8 @@ pub enum CoreError {
     CancelOrderNotCancellable,
     #[msg("Core Cancelation: purchaser mismatch")]
     CancelationPurchaserMismatch,
+    #[msg("Core Cancelation: payer mismatch")]
+    CancelationPayerMismatch,
     #[msg("Core Cancelation: market mismatch")]
     CancelationMarketMismatch,
     #[msg("Core Cancelation: market liquidities mismatch")]
@@ -81,8 +83,8 @@ pub enum CoreError {
      */
     #[msg("Core Settlement: market outcome index is not valid for market")]
     SettlementInvalidMarketOutcomeIndex,
-    #[msg("Core Settlement: purchaser mismatch")]
-    SettlementPurchaserMismatch,
+    #[msg("Core Settlement: payer mismatch")]
+    SettlementPayerMismatch,
     #[msg("Core Settlement: market mismatch")]
     SettlementMarketMismatch,
     #[msg("Core Settlement: market not open")]
@@ -324,8 +326,8 @@ pub enum CoreError {
     CloseAccountOrderNotComplete,
     #[msg("CloseAccount: MarketPosition not paid")]
     CloseAccountMarketPositionNotPaid,
-    #[msg("CloseAccount: Purchaser does not match")]
-    CloseAccountPurchaserMismatch,
+    #[msg("CloseAccount: Market authority does not match")]
+    CloseAccountMarketAuthorityMismatch,
     #[msg("CloseAccount: Payer does not match")]
     CloseAccountPayerMismatch,
     #[msg("CloseAccount: Market does not match")]

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -62,7 +62,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         ctx.accounts.market.decrement_account_counts()?;
         ctx.accounts
             .order
-            .close(ctx.accounts.purchaser.to_account_info())?;
+            .close(ctx.accounts.payer.to_account_info())?;
     }
 
     Ok(())

--- a/programs/monaco_protocol/src/instructions/order/settle_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/settle_order.rs
@@ -35,7 +35,7 @@ pub fn settle_order(ctx: Context<SettleOrder>) -> Result<()> {
         return ctx
             .accounts
             .order
-            .close(ctx.accounts.purchaser.to_account_info());
+            .close(ctx.accounts.payer.to_account_info());
     }
 
     if ctx.accounts.order.stake_unmatched > 0_u64 {

--- a/tests/end-to-end/inplay_market.ts
+++ b/tests/end-to-end/inplay_market.ts
@@ -217,7 +217,7 @@ describe("End to end test of", () => {
             .accounts({
               market: market.pk,
               order: order,
-              purchaser: purchaser.publicKey,
+              payer: monaco.operatorPk,
             })
             .rpc()
             .catch((e) => {
@@ -237,7 +237,7 @@ describe("End to end test of", () => {
             .accounts({
               market: market.pk,
               marketPosition: marketPosition,
-              purchaser: purchaser.publicKey,
+              payer: purchaser.publicKey,
             })
             .rpc()
             .catch((e) => {

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -105,6 +105,7 @@ describe("Security: Cancel Order", () => {
           ),
           purchaser: purchaserImpostor.publicKey, // impostor
           purchaserTokenAccount: purchaserImpostorTokenPk, // impostor
+          payer: purchaser.publicKey,
           market: market.pk,
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -171,6 +172,7 @@ describe("Security: Cancel Order", () => {
           ),
           purchaser: purchaserImpostor.publicKey, // impostor
           purchaserTokenAccount: purchaserImpostorTokenPk, // impostor
+          payer: purchaser.publicKey,
           market: market.pk,
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -232,6 +234,7 @@ describe("Security: Cancel Order", () => {
           ),
           purchaser: purchaser.publicKey,
           purchaserTokenAccount: purchaserImpostorTokenPk, // impostor
+          payer: purchaser.publicKey,
           market: market.pk,
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -298,6 +301,7 @@ describe("Security: Cancel Order", () => {
           ),
           purchaser: purchaser.publicKey,
           purchaserTokenAccount: purchaserImpostorTokenPk, // impostor
+          payer: purchaser.publicKey,
           market: market.pk,
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -367,6 +371,7 @@ describe("Security: Cancel Order", () => {
           ),
           purchaser: purchaser.publicKey,
           purchaserTokenAccount: purchaserInvalidTokenPk, // invalid
+          payer: purchaser.publicKey,
           market: market.pk,
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -471,6 +476,7 @@ describe("Security: Cancel Order", () => {
           purchaserTokenAccount: await market.cachePurchaserTokenPk(
             purchaser.publicKey,
           ),
+          payer: monaco.operatorPk,
           market: marketOther.marketPda, // invalid
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
@@ -539,6 +545,7 @@ describe("Security: Cancel Order", () => {
           purchaserTokenAccount: await market.cachePurchaserTokenPk(
             purchaser.publicKey,
           ),
+          payer: monaco.operatorPk,
           market: market.pk,
           marketEscrow: marketOther.escrowPda, // invalid
           marketLiquidities: market.liquiditiesPk,

--- a/tests/protocol/close_market_outcome.ts
+++ b/tests/protocol/close_market_outcome.ts
@@ -81,7 +81,7 @@ describe("Close market outcome accounts", () => {
       });
   });
 
-  it("close market outcome: purchaser mismatch", async () => {
+  it("close market outcome: authority mismatch", async () => {
     const price = 2.0;
     const marketOperator = await createWalletWithBalance(monaco.provider);
     await authoriseMarketOperator(
@@ -108,7 +108,10 @@ describe("Close market outcome accounts", () => {
       })
       .rpc()
       .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+        assert.equal(
+          e.error.errorCode.code,
+          "CloseAccountMarketAuthorityMismatch",
+        );
       });
   });
 

--- a/tests/protocol/close_market_position.ts
+++ b/tests/protocol/close_market_position.ts
@@ -45,7 +45,7 @@ describe("Close market position accounts", () => {
       .closeMarketPosition()
       .accounts({
         market: market.pk,
-        purchaser: purchaserA.publicKey,
+        payer: purchaserA.publicKey,
         marketPosition: marketPositionPk,
       })
       .rpc()
@@ -94,7 +94,7 @@ describe("Close market position accounts", () => {
       .closeMarketPosition()
       .accounts({
         market: market.pk,
-        purchaser: purchaserA.publicKey,
+        payer: purchaserA.publicKey,
         marketPosition: marketPositionPk,
       })
       .rpc()
@@ -103,7 +103,7 @@ describe("Close market position accounts", () => {
       });
   });
 
-  it("close market position: purchaser mismatch", async () => {
+  it("close market position: payer mismatch", async () => {
     const price = 2.0;
     const [purchaserA, purchaserB, market] = await Promise.all([
       createWalletWithBalance(monaco.provider),
@@ -136,12 +136,12 @@ describe("Close market position accounts", () => {
       .closeMarketPosition()
       .accounts({
         market: market.pk,
-        purchaser: purchaserB.publicKey,
+        payer: purchaserB.publicKey,
         marketPosition: marketPositionPk,
       })
       .rpc()
       .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+        assert.equal(e.error.errorCode.code, "CloseAccountPayerMismatch");
       });
   });
 
@@ -183,7 +183,7 @@ describe("Close market position accounts", () => {
       .closeMarketPosition()
       .accounts({
         market: marketB.pk,
-        purchaser: purchaserA.publicKey,
+        payer: purchaserA.publicKey,
         marketPosition: marketPositionPk,
       })
       .rpc()

--- a/tests/protocol/close_market_settlement.ts
+++ b/tests/protocol/close_market_settlement.ts
@@ -128,7 +128,7 @@ describe("Close market accounts (settled)", () => {
     }
   });
 
-  it("close market: purchaser mismatch", async () => {
+  it("close market: authority mismatch", async () => {
     const price = 2.0;
     const marketOperator = await createWalletWithBalance(monaco.provider);
     await authoriseMarketOperator(
@@ -155,9 +155,12 @@ describe("Close market accounts (settled)", () => {
           authority: monaco.operatorPk,
         })
         .rpc();
-      assert.fail("CloseAccountPurchaserMismatch expected");
+      assert.fail("CloseAccountMarketAuthorityMismatch expected");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+      assert.equal(
+        e.error.errorCode.code,
+        "CloseAccountMarketAuthorityMismatch",
+      );
     }
   });
 

--- a/tests/protocol/close_market_voided.ts
+++ b/tests/protocol/close_market_voided.ts
@@ -128,7 +128,7 @@ describe("Close market accounts (voided)", () => {
     }
   });
 
-  it("close market: purchaser mismatch", async () => {
+  it("close market: authority mismatch", async () => {
     const price = 2.0;
     const marketOperator = await createWalletWithBalance(monaco.provider);
     await authoriseMarketOperator(
@@ -155,9 +155,12 @@ describe("Close market accounts (voided)", () => {
           authority: monaco.operatorPk,
         })
         .rpc();
-      assert.fail("CloseAccountPurchaserMismatch expected");
+      assert.fail("CloseAccountMarketAuthorityMismatch expected");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+      assert.equal(
+        e.error.errorCode.code,
+        "CloseAccountMarketAuthorityMismatch",
+      );
     }
   });
 });

--- a/tests/protocol/close_order.ts
+++ b/tests/protocol/close_order.ts
@@ -14,8 +14,22 @@ describe("Close order accounts", () => {
 
     await market.airdrop(purchaserA, 100.0);
     await market.airdrop(purchaserB, 100.0);
-    const forOrder = await market.forOrder(0, 10, price, purchaserA);
-    const againstOrder = await market.againstOrder(0, 10, price, purchaserB);
+    const forOrder = await market.forOrder(
+      0,
+      10,
+      price,
+      purchaserA,
+      undefined,
+      purchaserA,
+    );
+    const againstOrder = await market.againstOrder(
+      0,
+      10,
+      price,
+      purchaserB,
+      undefined,
+      purchaserB,
+    );
 
     const balanceOrderCreated = await monaco.provider.connection.getBalance(
       purchaserA.publicKey,
@@ -38,7 +52,7 @@ describe("Close order accounts", () => {
       .closeOrder()
       .accounts({
         market: market.pk,
-        purchaser: purchaserA.publicKey,
+        payer: purchaserA.publicKey,
         order: forOrder,
       })
       .rpc()
@@ -78,7 +92,7 @@ describe("Close order accounts", () => {
       .closeOrder()
       .accounts({
         market: market.pk,
-        purchaser: purchaserA.publicKey,
+        payer: monaco.operatorPk,
         order: forOrder,
       })
       .rpc()
@@ -87,7 +101,7 @@ describe("Close order accounts", () => {
       });
   });
 
-  it("close order: purchaser mismatch", async () => {
+  it("close order: payer mismatch", async () => {
     const price = 2.0;
     const [purchaserA, purchaserB, market] = await Promise.all([
       createWalletWithBalance(monaco.provider),
@@ -113,12 +127,12 @@ describe("Close order accounts", () => {
       .closeOrder()
       .accounts({
         market: market.pk,
-        purchaser: purchaserB.publicKey,
+        payer: monaco.operatorPk,
         order: forOrder,
       })
       .rpc()
       .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+        assert.equal(e.error.errorCode.code, "CloseAccountPayerMismatch");
       });
   });
 
@@ -153,7 +167,7 @@ describe("Close order accounts", () => {
       .closeOrder()
       .accounts({
         market: marketB.pk,
-        purchaser: purchaserA.publicKey,
+        payer: monaco.operatorPk,
         order: forOrder,
       })
       .rpc()
@@ -182,7 +196,7 @@ describe("Close order accounts", () => {
       .closeOrder()
       .accounts({
         market: market.pk,
-        purchaser: purchaser.publicKey,
+        payer: monaco.operatorPk,
         order: forOrderPk,
       })
       .rpc()

--- a/tests/protocol/close_trade.ts
+++ b/tests/protocol/close_trade.ts
@@ -161,7 +161,7 @@ describe("Close trade accounts", () => {
       });
   });
 
-  it("close trade: purchaser mismatch", async () => {
+  it("close trade: payer mismatch", async () => {
     const price = 2.0;
     const [purchaserA, purchaserB, crankOperator, marketA, marketB] =
       await Promise.all([
@@ -206,7 +206,7 @@ describe("Close trade accounts", () => {
       })
       .rpc()
       .catch((e) => {
-        assert.equal(e.error.errorCode.code, "CloseAccountPurchaserMismatch");
+        assert.equal(e.error.errorCode.code, "CloseAccountPayerMismatch");
       });
   });
 });

--- a/tests/protocol/crank_settlement.ts
+++ b/tests/protocol/crank_settlement.ts
@@ -104,7 +104,7 @@ describe("Settlement Crank", () => {
         .settleOrder()
         .accounts({
           order: forOrderPda,
-          purchaser: wallet1.publicKey,
+          payer: monaco.operatorPk,
           market: marketOther.marketPda,
         })
         .rpc();
@@ -123,7 +123,7 @@ describe("Settlement Crank", () => {
         .settleOrder()
         .accounts({
           order: againstOrderPda,
-          purchaser: wallet2.publicKey,
+          payer: monaco.operatorPk,
           market: marketOther.marketPda,
         })
         .rpc();

--- a/tests/util/test_util.ts
+++ b/tests/util/test_util.ts
@@ -33,6 +33,7 @@ import {
   findMarketPda,
   findMarketPositionPda,
   findOrderPda,
+  MarketAccount,
   MarketPaymentsQueueAccount,
   PaymentInfo,
 } from "../../npm-client";
@@ -641,7 +642,7 @@ export async function processCommissionPayments(
     return;
   }
 
-  const market = await monaco.account.market.fetch(marketPk);
+  const market = (await monaco.account.market.fetch(marketPk)) as MarketAccount;
   const queuedItems = getPaymentInfoQueueItems(queue);
 
   const tx = new Transaction();
@@ -649,7 +650,7 @@ export async function processCommissionPayments(
     const productPk = item.to;
     const productEscrowPk = (
       await productProgram.account.product.fetch(productPk)
-    ).commissionEscrow;
+    ).commissionEscrow as PublicKey;
     const productEscrowTokenPk = await getOrCreateAssociatedTokenAccount(
       getAnchorProvider().connection,
       (getAnchorProvider().wallet as NodeWallet).payer,


### PR DESCRIPTION
Ensure that `payer` where relevant is where rent exemption fees are refunded to, rather than `purchaser` when data accounts are closed. 