### PR TITLE
fix: if back is not at end of vec enqueue must insert by index

### DIFF
--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -103,7 +103,7 @@ impl Cirque {
             let old_back = self.back();
             // #[soteria(ignore)] no overflows due to "if" check
             self.len += 1;
-            if self.items.len() < self.capacity() as usize {
+            if old_back as usize == self.items.len() {
                 self.items.push(item);
             } else {
                 self.items[old_back as usize] = item;
@@ -868,5 +868,25 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(item, *result.unwrap());
         assert_eq!(1, queue.len());
+    }
+
+    #[test]
+    fn test_cirque_enqueue_after_removal() {
+        let mut queue = Cirque::new(3);
+
+        let index_0 = Pubkey::new_unique();
+        let to_remove = Pubkey::new_unique();
+        let replacement = Pubkey::new_unique();
+
+        queue.enqueue(index_0);
+        queue.enqueue(to_remove);
+        queue.remove(&to_remove);
+        queue.enqueue(replacement);
+
+        assert_eq!(0, queue.front);
+        assert_eq!(2, queue.len());
+
+        let expected_items = vec![index_0, replacement];
+        assert_eq!(expected_items, queue.items);
     }
 }


### PR DESCRIPTION
MMP's Cirque was recently updated not to initialise full of default values but rather to just initialise as empty and grow into the space that is required. This should help with serdes given there tends to be so many MMPs created but with few orders in many. 

A bug was introduced at this point, as enqueue could no longer arbitrarily index into the full size storage vector, the vector had to be grown when appropriate on enqueue, or if possible, indexed into to replace some existing data. The condition to grow/push rather than replace was a little too greedy, and so it was possible that a new value enqueued after a value had been removed ended up being placed at the end of the storage vec, rather than replacing the element after the end of the queue. 

An alternative fix would be to prune the end of the storage vec on removal, but I think that's a larger change than the fix here, where we only grow on enqueue when required, and otherwise we replace at the required index. 