### PR TITLE
fix: update handling of liquidity queues and pools at inplay transition

### DIFF
--- a/npm-client/src/cancel_order_instruction.ts
+++ b/npm-client/src/cancel_order_instruction.ts
@@ -17,6 +17,7 @@ import { findMarketMatchingPoolPda } from "./market_matching_pools";
 import { findMarketOutcomePda } from "./market_outcomes";
 import { getCancellableOrdersByMarketForProviderWallet } from "./order_query";
 import { findMarketLiquiditiesPda } from "./market_liquidities";
+import { findMarketMatchingQueuePda } from "./market_matching_queues";
 
 /**
  * Constructs the instruction required to perform a cancel order transaction.
@@ -64,6 +65,7 @@ export async function buildCancelOrderInstruction(
     marketOutcomePda,
     escrowPda,
     liquiditiesPda,
+    matchingQueuePda,
     purchaserTokenAccount,
   ] = await Promise.all([
     findMarketPositionPda(program, order.market, provider.wallet.publicKey),
@@ -77,6 +79,7 @@ export async function buildCancelOrderInstruction(
     findMarketOutcomePda(program, order.market, order.marketOutcomeIndex),
     findEscrowPda(program, order.market),
     findMarketLiquiditiesPda(program, order.market),
+    findMarketMatchingQueuePda(program, order.market),
     getWalletTokenAccount(program, mintPk),
   ]);
 
@@ -93,6 +96,7 @@ export async function buildCancelOrderInstruction(
       market: order.market,
       marketEscrow: escrowPda.data.pda,
       marketLiquidities: liquiditiesPda.data.pda,
+      marketMatchingQueue: matchingQueuePda.data.pda,
       mint: mintPk,
       tokenProgram: TOKEN_PROGRAM_ID,
     })
@@ -135,12 +139,14 @@ export async function buildCancelOrdersForMarketInstructions(
     marketPositionPda,
     escrowPda,
     liquiditiesPda,
+    matchingQueuePda,
     purchaserTokenAccount,
     ordersResponse,
   ] = await Promise.all([
     findMarketPositionPda(program, marketPk, provider.wallet.publicKey),
     findEscrowPda(program, marketPk),
     findMarketLiquiditiesPda(program, marketPk),
+    findMarketMatchingQueuePda(program, marketPk),
     getWalletTokenAccount(program, marketTokenPk),
     getCancellableOrdersByMarketForProviderWallet(program, marketPk),
   ]);
@@ -183,6 +189,7 @@ export async function buildCancelOrdersForMarketInstructions(
           market: order.account.market,
           marketEscrow: escrowPda.data.pda,
           marketLiquidities: liquiditiesPda.data.pda,
+          marketMatchingQueue: matchingQueuePda.data.pda,
           mint: market.mintAccount,
           tokenProgram: TOKEN_PROGRAM_ID,
         })

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -1068,9 +1068,11 @@ pub struct SettleMarket<'info> {
 }
 
 #[derive(Accounts)]
-pub struct UpdateMarketUnauthorized<'info> {
+pub struct MoveMarketToInplay<'info> {
     #[account(mut)]
     pub market: Account<'info, Market>,
+    #[account(mut, has_one = market)]
+    pub market_liquidities: Account<'info, MarketLiquidities>,
 }
 
 #[derive(Accounts)]

--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -239,6 +239,8 @@ pub struct DequeueOrderRequest<'info> {
 #[derive(Accounts)]
 pub struct UpdateMarketMatchingPool<'info> {
     pub market: Account<'info, Market>,
+    #[account(has_one = market)]
+    pub market_matching_queue: Account<'info, MarketMatchingQueue>,
     #[account(mut, has_one = market)]
     pub market_matching_pool: Account<'info, MarketMatchingPool>,
 }
@@ -273,6 +275,8 @@ pub struct CancelOrder<'info> {
         constraint = market_outcome.index == order.market_outcome_index @ CoreError::CancelationMarketOutcomeMismatch,
     )]
     pub market_outcome: Account<'info, MarketOutcome>,
+    #[account(has_one = market)]
+    pub market_matching_queue: Account<'info, MarketMatchingQueue>,
     #[account(
         mut,
         seeds = [

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -229,6 +229,8 @@ pub enum CoreError {
      */
     #[msg("The order is currently within the inplay delay period and the operation cannot be completed")]
     InplayDelay,
+    #[msg("Operation cannot currently be completed - market matching queue is not yet empty for inplay transition")]
+    InplayTransitionMarketMatchingQueueIsNotEmpty,
 
     /*
     Market Type

--- a/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
+++ b/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
@@ -4,8 +4,12 @@ use crate::error::CoreError;
 use crate::instructions::current_timestamp;
 use crate::state::market_account::Market;
 use crate::state::market_account::MarketStatus::Open;
+use crate::state::market_liquidities::MarketLiquidities;
 
-pub fn move_market_to_inplay(market: &mut Market) -> Result<()> {
+pub fn move_market_to_inplay(
+    market: &mut Market,
+    market_liquidities: &mut MarketLiquidities,
+) -> Result<()> {
     let now = current_timestamp();
 
     require!(
@@ -25,7 +29,8 @@ pub fn move_market_to_inplay(market: &mut Market) -> Result<()> {
         CoreError::MarketEventNotStarted,
     );
 
-    market.inplay = true;
+    market.move_to_inplay();
+    market_liquidities.move_to_inplay(&market.event_start_order_behaviour);
 
     Ok(())
 }
@@ -34,51 +39,70 @@ pub fn move_market_to_inplay(market: &mut Market) -> Result<()> {
 mod tests {
     use crate::instructions::current_timestamp;
     use crate::instructions::market::move_market_to_inplay;
-    use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
+    use crate::state::market_account::{mock_market, Market, MarketOrderBehaviour, MarketStatus};
+    use crate::state::market_liquidities::{mock_market_liquidities, MarketLiquidities};
+    use solana_program::pubkey::Pubkey;
 
     fn market_setup() -> Market {
-        let market = Market {
-            authority: Default::default(),
-            event_account: Default::default(),
-            mint_account: Default::default(),
-            decimal_limit: 2,
-            market_outcomes_count: 3_u16,
-            market_winning_outcome_index: Some(1),
-            market_type: Default::default(),
-            market_type_discriminator: None,
-            market_type_value: None,
-            market_settle_timestamp: None,
-            title: "".to_string(),
-            unsettled_accounts_count: 0,
-            market_status: MarketStatus::Open,
-            escrow_account_bump: 0,
-            published: false,
-            suspended: false,
-            inplay_order_delay: 0,
-            event_start_order_behaviour: MarketOrderBehaviour::None,
-            market_lock_order_behaviour: MarketOrderBehaviour::None,
-            market_lock_timestamp: current_timestamp() + 1000000001,
-            event_start_timestamp: current_timestamp() - 1000000000,
-            inplay_enabled: true,
-            inplay: false,
-            version: 0,
-            unclosed_accounts_count: 0,
-        };
+        let mut market = mock_market(MarketStatus::Open);
+        market.inplay_enabled = true;
+        market.inplay = false;
+        market.market_lock_timestamp = current_timestamp() + 1000000001;
+        market.event_start_timestamp = current_timestamp() - 1000000000;
+        market.event_start_order_behaviour = MarketOrderBehaviour::CancelUnmatched;
         return market;
+    }
+
+    fn liquidities_setup() -> MarketLiquidities {
+        let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
+        market_liquidities.add_liquidity_for(0, 2.0, 1).expect("");
+        market_liquidities.add_liquidity_for(0, 3.0, 1).expect("");
+        market_liquidities.add_liquidity_for(0, 4.0, 1).expect("");
+        market_liquidities
+            .add_liquidity_against(0, 2.0, 1)
+            .expect("");
+        market_liquidities
+            .add_liquidity_against(0, 3.0, 1)
+            .expect("");
+        market_liquidities
+            .add_liquidity_against(0, 4.0, 1)
+            .expect("");
+        return market_liquidities;
     }
 
     #[test]
     fn test_market_move_to_inplay_success() {
         let mut market: Market = market_setup();
-        let result = move_market_to_inplay(&mut market);
+        let mut market_liquidities = liquidities_setup();
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_ok());
+        assert_eq!(0, market_liquidities.liquidities_for.len());
+        assert_eq!(0, market_liquidities.liquidities_against.len());
+    }
+
+    #[test]
+    fn test_market_move_to_inplay_not_cancel_unmatched_success() {
+        let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
+        let for_len_before = market_liquidities.liquidities_for.len();
+        let against_len_before = market_liquidities.liquidities_against.len();
+        assert!(for_len_before > 0 && against_len_before > 0);
+        market.event_start_order_behaviour = MarketOrderBehaviour::None;
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
+        assert!(result.is_ok());
+        assert_eq!(for_len_before, market_liquidities.liquidities_for.len());
+        assert_eq!(
+            against_len_before,
+            market_liquidities.liquidities_against.len()
+        );
     }
 
     #[test]
     fn test_market_move_to_inplay_failure_not_inplay() {
         let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
         market.inplay_enabled = false;
-        let result = move_market_to_inplay(&mut market);
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -89,8 +113,9 @@ mod tests {
     #[test]
     fn test_market_move_to_inplay_not_started() {
         let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
         market.event_start_timestamp = current_timestamp() + 1000000000;
-        let result = move_market_to_inplay(&mut market);
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -101,8 +126,9 @@ mod tests {
     #[test]
     fn test_market_move_to_inplay_failure_already_inplay() {
         let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
         market.inplay = true;
-        let result = move_market_to_inplay(&mut market);
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -113,8 +139,9 @@ mod tests {
     #[test]
     fn test_market_move_to_inplay_failure_market_not_open_initializing() {
         let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
         market.market_status = MarketStatus::Initializing;
-        let result = move_market_to_inplay(&mut market);
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -125,8 +152,9 @@ mod tests {
     #[test]
     fn test_market_move_to_inplay_failure_market_not_open_settled() {
         let mut market: Market = market_setup();
+        let mut market_liquidities = liquidities_setup();
         market.market_status = MarketStatus::Settled;
-        let result = move_market_to_inplay(&mut market);
+        let result = move_market_to_inplay(&mut market, &mut market_liquidities);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -102,8 +102,12 @@ pub fn move_market_matching_pool_to_inplay(
         !market_matching_pool.inplay,
         CoreError::MatchingMarketMatchingPoolAlreadyInplay
     );
-
-    market_matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)
+    require!(
+        market_matching_queue.matches.is_empty(),
+        CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+    );
+    market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+    Ok(())
 }
 
 pub fn update_matching_pool_with_matched_order(
@@ -146,7 +150,11 @@ pub fn update_on_cancel(
     order: &Account<Order>,
 ) -> Result<bool> {
     if market.is_inplay() && !matching_pool.inplay {
-        matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)?;
+        require!(
+            market_matching_queue.matches.is_empty(),
+            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+        );
+        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
     if matching_pool.orders.remove(&order.key()).is_some() {

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::state::market_account::{Market, MarketStatus};
 use crate::state::market_matching_pool_account::MarketMatchingPool;
+use crate::state::market_matching_queue_account::MarketMatchingQueue;
 use crate::state::market_outcome_account::MarketOutcome;
 use crate::{CoreError, Order};
 
@@ -55,14 +56,9 @@ pub fn update_on_match(
 }
 
 pub fn update_matching_pool_with_new_order(
-    market: &Market,
     market_matching_pool: &mut MarketMatchingPool,
     order_account: &Account<Order>,
 ) -> Result<()> {
-    if market.is_inplay() && !market_matching_pool.inplay {
-        market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
-    }
-
     market_matching_pool.liquidity_amount = market_matching_pool
         .liquidity_amount
         .checked_add(order_account.stake_unmatched)
@@ -90,6 +86,7 @@ pub fn update_matching_pool_with_new_order(
 
 pub fn move_market_matching_pool_to_inplay(
     market: &Market,
+    market_matching_queue: &MarketMatchingQueue,
     market_matching_pool: &mut MarketMatchingPool,
 ) -> Result<()> {
     require!(
@@ -106,9 +103,7 @@ pub fn move_market_matching_pool_to_inplay(
         CoreError::MatchingMarketMatchingPoolAlreadyInplay
     );
 
-    market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
-
-    Ok(())
+    market_matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)
 }
 
 pub fn update_matching_pool_with_matched_order(
@@ -145,12 +140,13 @@ pub fn update_matching_pool_with_matched_order(
 }
 
 pub fn update_on_cancel(
-    order: &Account<Order>,
-    matching_pool: &mut MarketMatchingPool,
     market: &Market,
+    market_matching_queue: &MarketMatchingQueue,
+    matching_pool: &mut MarketMatchingPool,
+    order: &Account<Order>,
 ) -> Result<bool> {
     if market.is_inplay() && !matching_pool.inplay {
-        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+        matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)?;
     }
 
     if matching_pool.orders.remove(&order.key()).is_some() {

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -147,13 +147,14 @@ pub fn update_matching_pool_with_matched_order(
 pub fn update_on_cancel(
     order: &Account<Order>,
     matching_pool: &mut MarketMatchingPool,
-) -> Result<()> {
+) -> Result<bool> {
     if matching_pool.orders.remove(&order.key()).is_some() {
         matching_pool.liquidity_amount = matching_pool
             .liquidity_amount
             .checked_sub(order.voided_stake)
             .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
+        Ok(true)
+    } else {
+        Ok(false)
     }
-
-    Ok(())
 }

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -147,7 +147,12 @@ pub fn update_matching_pool_with_matched_order(
 pub fn update_on_cancel(
     order: &Account<Order>,
     matching_pool: &mut MarketMatchingPool,
+    market: &Market,
 ) -> Result<bool> {
+    if market.is_inplay() && !matching_pool.inplay {
+        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+    }
+
     if matching_pool.orders.remove(&order.key()).is_some() {
         matching_pool.liquidity_amount = matching_pool
             .liquidity_amount

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -37,13 +37,15 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
 
     ctx.accounts.order.void_stake_unmatched();
 
+    let market_matching_queue = &ctx.accounts.market_matching_queue;
     let order = &ctx.accounts.order;
 
     // remove from matching pool
     let removed_from_queue = matching::matching_pool::update_on_cancel(
-        order,
-        &mut ctx.accounts.market_matching_pool,
         market,
+        market_matching_queue,
+        &mut ctx.accounts.market_matching_pool,
+        order,
     )?;
 
     // update liquidity iff the order was still present in the liquidity pool

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -48,7 +48,7 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         order,
     )?;
 
-    // update liquidity iff the order was still present in the liquidity pool
+    // update liquidity if the order was still present in the matching pool
     if removed_from_queue {
         match order.for_outcome {
             true => market_liquidities

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::context::CancelOrder;
 use crate::error::CoreError;
+use crate::instructions::market::move_market_to_inplay;
 use crate::instructions::{market_position, matching, transfer};
 use crate::state::market_account::MarketStatus;
 use crate::state::order_account::*;
@@ -24,48 +25,61 @@ pub fn cancel_order(ctx: Context<CancelOrder>) -> Result<()> {
         CoreError::CancelOrderNotCancellable
     );
 
-    // remove from matching pool
-    let removed_from_queue =
-        matching::matching_pool::update_on_cancel(order, &mut ctx.accounts.market_matching_pool)?;
+    let market = &mut ctx.accounts.market;
+    let market_liquidities = &mut ctx.accounts.market_liquidities;
 
-    // update liquidity iff the order was still present in the liquidity pool
-    if removed_from_queue {
-        match order.for_outcome {
-            true => ctx
-                .accounts
-                .market_liquidities
-                .remove_liquidity_for(
-                    order.market_outcome_index,
-                    order.expected_price,
-                    order.stake_unmatched,
-                )
-                .map_err(|_| CoreError::CancelOrderNotCancellable)?,
-            false => ctx
-                .accounts
-                .market_liquidities
-                .remove_liquidity_against(
-                    order.market_outcome_index,
-                    order.expected_price,
-                    order.stake_unmatched,
-                )
-                .map_err(|_| CoreError::CancelOrderNotCancellable)?,
-        }
+    // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
+    // and zero liquidities before cancelling the order if that's what the market is
+    // configured for
+    if market.is_inplay() && !market.inplay {
+        move_market_to_inplay(market, market_liquidities)?;
     }
+
     ctx.accounts.order.void_stake_unmatched();
 
     let order = &ctx.accounts.order;
 
     // remove from matching pool
-    matching::matching_pool::update_on_cancel(order, &mut ctx.accounts.market_matching_pool)?;
+    let removed_from_queue = matching::matching_pool::update_on_cancel(
+        order,
+        &mut ctx.accounts.market_matching_pool,
+        market,
+    )?;
+
+    // update liquidity iff the order was still present in the liquidity pool
+    if removed_from_queue {
+        match order.for_outcome {
+            true => market_liquidities
+                .remove_liquidity_for(
+                    order.market_outcome_index,
+                    order.expected_price,
+                    order.voided_stake,
+                )
+                .map_err(|_| CoreError::CancelOrderNotCancellable)?,
+            false => market_liquidities
+                .remove_liquidity_against(
+                    order.market_outcome_index,
+                    order.expected_price,
+                    order.voided_stake,
+                )
+                .map_err(|_| CoreError::CancelOrderNotCancellable)?,
+        }
+    }
 
     // calculate refund
     let refund =
         market_position::update_on_order_cancellation(&mut ctx.accounts.market_position, order)?;
-    transfer::order_cancelation_refund(&ctx, refund)?;
+    transfer::order_cancelation_refund(
+        &ctx.accounts.market_escrow,
+        &ctx.accounts.purchaser_token_account,
+        &ctx.accounts.token_program,
+        market,
+        refund,
+    )?;
 
     // if never matched close
     if order.stake == order.voided_stake {
-        ctx.accounts.market.decrement_account_counts()?;
+        market.decrement_account_counts()?;
         ctx.accounts
             .order
             .close(ctx.accounts.payer.to_account_info())?;

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -52,10 +52,6 @@ pub fn cancel_preplay_order_post_event_start(
             CoreError::CancelationPreplayOrderRequestsExist
         );
     }
-    require!(
-        matching_queue.matches.is_empty(),
-        CoreError::MatchingQueueIsNotEmpty
-    );
 
     // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
     // and zero liquidities before cancelling the order if that's what the market is
@@ -64,7 +60,7 @@ pub fn cancel_preplay_order_post_event_start(
         move_market_to_inplay(market, market_liquidities)?;
     }
     if !market_matching_pool.inplay {
-        market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+        market_matching_pool.move_to_inplay(matching_queue, &market.event_start_order_behaviour)?;
     }
 
     order.void_stake_unmatched(); // <-- void needs to happen before refund calculation
@@ -475,7 +471,7 @@ mod test {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            error!(CoreError::MatchingQueueIsNotEmpty)
+            error!(CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty)
         );
     }
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::error::CoreError;
+use crate::instructions::market::move_market_to_inplay;
 use crate::instructions::market_position;
 use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
 use crate::state::market_liquidities::MarketLiquidities;
@@ -56,27 +57,16 @@ pub fn cancel_preplay_order_post_event_start(
         CoreError::MatchingQueueIsNotEmpty
     );
 
+    // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
+    // and zero liquidities before cancelling the order if that's what the market is
+    // configured for
+    if market.is_inplay() && !market.inplay {
+        move_market_to_inplay(market, market_liquidities)?;
+    }
     if !market_matching_pool.inplay {
         market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
-    // update liquidity
-    match order.for_outcome {
-        true => market_liquidities
-            .remove_liquidity_for(
-                order.market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .map_err(|_| CoreError::CancelationLowLiquidity)?,
-        false => market_liquidities
-            .remove_liquidity_against(
-                order.market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .map_err(|_| CoreError::CancelationLowLiquidity)?,
-    }
     order.void_stake_unmatched(); // <-- void needs to happen before refund calculation
     let refund = market_position::update_on_order_cancellation(market_position, order)?;
 
@@ -92,6 +82,7 @@ pub fn cancel_preplay_order_post_event_start(
 #[cfg(test)]
 mod test {
     use crate::state::market_account::MarketStatus;
+    use crate::state::market_liquidities::mock_market_liquidities;
     use crate::state::market_matching_pool_account::Cirque;
     use crate::state::market_matching_queue_account::{mock_market_matching_queue, OrderMatch};
     use crate::state::market_order_request_queue::{mock_order_request_queue, OrderRequest};
@@ -107,6 +98,7 @@ mod test {
 
         let market_pk = Pubkey::new_unique();
         let mut market = mock_market();
+
         let mut market_liquidities = mock_market_liquidities(market_pk);
 
         let order_request = OrderRequest {
@@ -144,10 +136,6 @@ mod test {
         let mut market_matching_pool =
             mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
 
-        market_liquidities
-            .add_liquidity_against(market_outcome_index, matched_price, order.stake)
-            .unwrap();
-
         let mut market_position = MarketPosition::default();
         market_position.market_outcome_sums.resize(3, 0_i128);
         market_position.unmatched_exposures.resize(3, 0_u64);
@@ -172,81 +160,6 @@ mod test {
         assert_eq!(
             result.unwrap_err(),
             error!(CoreError::CancelationOrderStatusInvalid)
-        );
-    }
-
-    #[test]
-    fn error_not_enough_liquidity() {
-        let market_outcome_index = 1;
-        let matched_price = 2.2_f64;
-        let payer_pk = Pubkey::new_unique();
-
-        let market_pk = Pubkey::new_unique();
-        let mut market = mock_market();
-        let mut market_liquidities = mock_market_liquidities(market_pk);
-
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
-
-        let mut order = Order {
-            purchaser: Pubkey::new_unique(),
-            market: market_pk,
-            market_outcome_index,
-            for_outcome: false,
-            order_status: OrderStatus::Matched,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            stake_unmatched: 10_u64,
-            voided_stake: 0_u64,
-            payout: 0_u64,
-            creation_timestamp: 0,
-            payer: payer_pk,
-        };
-        let matching_queue = &mock_market_matching_queue(market_pk);
-        let order_request_queue = &mock_order_request_queue(market_pk);
-
-        let mut market_matching_pool =
-            mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
-
-        market_liquidities
-            .add_liquidity_against(market_outcome_index, matched_price, order.stake)
-            .unwrap();
-        let mut market_position = MarketPosition::default();
-        market_position.market_outcome_sums.resize(3, 0_i128);
-        market_position.unmatched_exposures.resize(3, 0_u64);
-        let update_on_order_creation =
-            market_position::update_on_order_request_creation(&mut market_position, &order_request);
-        assert!(update_on_order_creation.is_ok());
-        assert_eq!(vec!(0, 140, 0), market_position.unmatched_exposures);
-
-        // when
-        let result = cancel_preplay_order_post_event_start(
-            &mut market,
-            &mut market_liquidities,
-            &mut market_matching_pool,
-            &mut order,
-            &mut market_position,
-            &matching_queue,
-            &order_request_queue,
-        );
-
-        // then
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            error!(CoreError::CancelationLowLiquidity)
         );
     }
 
@@ -297,13 +210,6 @@ mod test {
         let mut market_matching_pool =
             mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
 
-        market_liquidities
-            .add_liquidity_against(
-                market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .unwrap();
         market_position::update_on_order_request_creation(&mut market_position, &order_request)
             .unwrap();
         market_position::update_on_order_match(
@@ -404,14 +310,6 @@ mod test {
 
         let mut market_matching_pool =
             mock_market_matching_pool(market_pk, market_outcome_index, matched_price);
-
-        market_liquidities
-            .add_liquidity_against(
-                market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .unwrap();
 
         let result = cancel_preplay_order_post_event_start(
             &mut market,
@@ -608,14 +506,6 @@ mod test {
             unclosed_accounts_count: 0,
             escrow_account_bump: 0,
             event_start_timestamp: 100,
-        }
-    }
-
-    fn mock_market_liquidities(market: Pubkey) -> MarketLiquidities {
-        MarketLiquidities {
-            market,
-            liquidities_for: vec![],
-            liquidities_against: vec![],
         }
     }
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -60,7 +60,11 @@ pub fn cancel_preplay_order_post_event_start(
         move_market_to_inplay(market, market_liquidities)?;
     }
     if !market_matching_pool.inplay {
-        market_matching_pool.move_to_inplay(matching_queue, &market.event_start_order_behaviour)?;
+        require!(
+            matching_queue.matches.is_empty(),
+            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+        );
+        market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
     order.void_stake_unmatched(); // <-- void needs to happen before refund calculation

--- a/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
+++ b/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use solana_program::clock::UnixTimestamp;
 
 use crate::error::CoreError;
+use crate::instructions::market::move_market_to_inplay;
 use crate::instructions::market_position::update_product_commission_contributions;
 use crate::instructions::order::initialize_order;
 use crate::instructions::{
@@ -30,19 +31,28 @@ pub fn process_order_request(
         .dequeue()
         .ok_or(CoreError::OrderRequestQueueIsEmpty)?;
 
-    // if market is inplay, and order is delayed, check if delay has expired
-    if market.is_inplay() && order_request.delay_expiration_timestamp > 0 {
-        let now: UnixTimestamp = current_timestamp();
-        require!(
-            order_request.delay_expiration_timestamp <= now,
-            CoreError::InplayDelay
-        );
+    if market.is_inplay() {
+        // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
+        // and zero liquidities before processing the order request if that's
+        // what the market is configured for
+        if !market.inplay {
+            move_market_to_inplay(market, market_liquidities)?;
+        }
+
+        // if market is inplay, and order is delayed, processing requires that the delay has expired
+        if order_request.delay_expiration_timestamp > 0 {
+            let now: UnixTimestamp = current_timestamp();
+            require!(
+                order_request.delay_expiration_timestamp <= now,
+                CoreError::InplayDelay
+            );
+        }
     }
 
     initialize_order(order, market, fee_payer, *order_request)?;
     market.increment_account_counts()?;
 
-    // pools are always initialized with default items, so if this pool is new, initialize it
+    // if this pool is new, initialize it
     if matching_pool.orders.capacity() == 0 {
         market::initialize_market_matching_pool(matching_pool, market, order)?;
         market.increment_unclosed_accounts_count()?;

--- a/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
+++ b/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
@@ -57,6 +57,9 @@ pub fn process_order_request(
         market::initialize_market_matching_pool(matching_pool, market, order)?;
         market.increment_unclosed_accounts_count()?;
     }
+    if market.is_inplay() && !matching_pool.inplay {
+        matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)?;
+    }
 
     let order_matches = matching::on_order_creation(
         market_liquidities,
@@ -64,7 +67,7 @@ pub fn process_order_request(
         &order.key(),
         order,
     )?;
-    matching::update_matching_pool_with_new_order(market, matching_pool, order)?;
+    matching::update_matching_pool_with_new_order(matching_pool, order)?;
 
     // calculate payment
     let mut total_refund = 0_u64;

--- a/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
+++ b/programs/monaco_protocol/src/instructions/order_request/process_order_request.rs
@@ -58,7 +58,11 @@ pub fn process_order_request(
         market.increment_unclosed_accounts_count()?;
     }
     if market.is_inplay() && !matching_pool.inplay {
-        matching_pool.move_to_inplay(market_matching_queue, &market.event_start_order_behaviour)?;
+        require!(
+            market_matching_queue.matches.is_empty(),
+            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+        );
+        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
     let order_matches = matching::on_order_creation(

--- a/programs/monaco_protocol/src/instructions/transfer.rs
+++ b/programs/monaco_protocol/src/instructions/transfer.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token;
 use anchor_spl::token::{Token, TokenAccount};
 
-use crate::context::{CancelOrder, MatchOrders, SettleMarketPosition, VoidMarketPosition};
+use crate::context::{MatchOrders, SettleMarketPosition, VoidMarketPosition};
 use crate::state::market_account::Market;
 
 pub fn order_creation_payment<'info>(
@@ -37,14 +37,18 @@ pub fn order_creation_refund<'info>(
     )
 }
 
-pub fn order_cancelation_refund(ctx: &Context<CancelOrder>, amount: u64) -> Result<()> {
-    let accounts = &ctx.accounts;
-
+pub fn order_cancelation_refund<'info>(
+    market_escrow: &Account<'info, TokenAccount>,
+    purchaser_token_account: &Account<'info, TokenAccount>,
+    token_program: &Program<'info, Token>,
+    market: &Account<'info, Market>,
+    amount: u64,
+) -> Result<()> {
     transfer_from_market_escrow(
-        &accounts.market_escrow,
-        &accounts.purchaser_token_account,
-        &accounts.token_program,
-        &accounts.market,
+        market_escrow,
+        purchaser_token_account,
+        token_program,
+        market,
         amount,
     )
 }

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -114,6 +114,7 @@ pub mod monaco_protocol {
     ) -> Result<()> {
         instructions::matching::move_market_matching_pool_to_inplay(
             &ctx.accounts.market,
+            &ctx.accounts.market_matching_queue,
             &mut ctx.accounts.market_matching_pool,
         )
     }

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -528,9 +528,11 @@ pub mod monaco_protocol {
         instructions::market::update_market_event_start_time_to_now(market)
     }
 
-    pub fn move_market_to_inplay(ctx: Context<UpdateMarketUnauthorized>) -> Result<()> {
-        let market = &mut ctx.accounts.market;
-        instructions::market::move_market_to_inplay(market)
+    pub fn move_market_to_inplay(ctx: Context<MoveMarketToInplay>) -> Result<()> {
+        instructions::market::move_market_to_inplay(
+            &mut ctx.accounts.market,
+            &mut ctx.accounts.market_liquidities,
+        )
     }
 
     pub fn open_market(ctx: Context<OpenMarket>) -> Result<()> {

--- a/programs/monaco_protocol/src/state/market_account.rs
+++ b/programs/monaco_protocol/src/state/market_account.rs
@@ -128,6 +128,10 @@ impl Market {
     pub fn market_is_inplay(market: &Market, now: UnixTimestamp) -> bool {
         market.inplay || (market.inplay_enabled && market.event_start_timestamp <= now)
     }
+
+    pub fn move_to_inplay(&mut self) {
+        self.inplay = true;
+    }
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/programs/monaco_protocol/src/state/market_liquidities.rs
+++ b/programs/monaco_protocol/src/state/market_liquidities.rs
@@ -4,6 +4,7 @@ use std::string::ToString;
 use anchor_lang::prelude::*;
 
 use crate::error::CoreError;
+use crate::state::market_account::MarketOrderBehaviour;
 use crate::state::type_size::*;
 
 #[account]
@@ -181,6 +182,14 @@ impl MarketLiquidities {
             }
 
             Ordering::Equal
+        }
+    }
+
+    pub fn move_to_inplay(&mut self, market_event_start_order_behaviour: &MarketOrderBehaviour) {
+        // Reset liquidities when market moves to inplay if that's the desired behaviour
+        if market_event_start_order_behaviour.eq(&MarketOrderBehaviour::CancelUnmatched) {
+            self.liquidities_for = Vec::new();
+            self.liquidities_against = Vec::new();
         }
     }
 }

--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -1,3 +1,5 @@
+use crate::error::CoreError;
+use crate::state::market_matching_queue_account::MarketMatchingQueue;
 use crate::state::type_size::*;
 use anchor_lang::prelude::*;
 use std::string::ToString;
@@ -31,13 +33,23 @@ impl MarketMatchingPool {
         BOOL_SIZE + // inplay
         Cirque::size_for(MarketMatchingPool::QUEUE_LENGTH); //orders
 
-    pub fn move_to_inplay(&mut self, market_event_start_order_behaviour: &MarketOrderBehaviour) {
+    pub fn move_to_inplay(
+        &mut self,
+        market_matching_queue: &MarketMatchingQueue,
+        market_event_start_order_behaviour: &MarketOrderBehaviour,
+    ) -> Result<()> {
+        require!(
+            market_matching_queue.matches.is_empty(),
+            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+        );
+
         self.inplay = true;
 
         if market_event_start_order_behaviour.eq(&MarketOrderBehaviour::CancelUnmatched) {
             self.orders.set_length_to_zero();
             self.liquidity_amount = 0_u64;
         }
+        Ok(())
     }
 }
 

--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -103,7 +103,7 @@ impl Cirque {
             let old_back = self.back();
             // #[soteria(ignore)] no overflows due to "if" check
             self.len += 1;
-            if self.items.len() < self.capacity() as usize {
+            if old_back as usize == self.items.len() {
                 self.items.push(item);
             } else {
                 self.items[old_back as usize] = item;
@@ -868,5 +868,25 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(item, *result.unwrap());
         assert_eq!(1, queue.len());
+    }
+
+    #[test]
+    fn test_cirque_enqueue_after_removal() {
+        let mut queue = Cirque::new(3);
+
+        let index_0 = Pubkey::new_unique();
+        let to_remove = Pubkey::new_unique();
+        let replacement = Pubkey::new_unique();
+
+        queue.enqueue(index_0);
+        queue.enqueue(to_remove);
+        queue.remove(&to_remove);
+        queue.enqueue(replacement);
+
+        assert_eq!(0, queue.front);
+        assert_eq!(2, queue.len());
+
+        let expected_items = vec![index_0, replacement];
+        assert_eq!(expected_items, queue.items);
     }
 }

--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -1,5 +1,3 @@
-use crate::error::CoreError;
-use crate::state::market_matching_queue_account::MarketMatchingQueue;
 use crate::state::type_size::*;
 use anchor_lang::prelude::*;
 use std::string::ToString;
@@ -33,23 +31,13 @@ impl MarketMatchingPool {
         BOOL_SIZE + // inplay
         Cirque::size_for(MarketMatchingPool::QUEUE_LENGTH); //orders
 
-    pub fn move_to_inplay(
-        &mut self,
-        market_matching_queue: &MarketMatchingQueue,
-        market_event_start_order_behaviour: &MarketOrderBehaviour,
-    ) -> Result<()> {
-        require!(
-            market_matching_queue.matches.is_empty(),
-            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
-        );
-
+    pub fn move_to_inplay(&mut self, market_event_start_order_behaviour: &MarketOrderBehaviour) {
         self.inplay = true;
 
         if market_event_start_order_behaviour.eq(&MarketOrderBehaviour::CancelUnmatched) {
             self.orders.set_length_to_zero();
             self.liquidity_amount = 0_u64;
         }
-        Ok(())
     }
 }
 

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -110,6 +110,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -177,6 +178,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -239,6 +241,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -306,6 +309,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -376,6 +380,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -481,6 +486,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: market.escrowPk,
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,
@@ -550,6 +556,7 @@ describe("Security: Cancel Order", () => {
           marketEscrow: marketOther.escrowPda, // invalid
           marketLiquidities: market.liquiditiesPk,
           marketOutcome: market.outcomePks[outcomeIndex],
+          marketMatchingQueue: market.matchingQueuePk,
           marketMatchingPool:
             market.matchingPools[outcomeIndex][price].forOutcome,
           tokenProgram: TOKEN_PROGRAM_ID,

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1074,6 +1074,7 @@ export class MonacoMarket {
         marketEscrow: this.escrowPk,
         marketLiquidities: this.liquiditiesPk,
         marketOutcome: outcomePk,
+        marketMatchingQueue: this.matchingQueuePk,
         marketMatchingPool: matchingPoolPk,
         tokenProgram: TOKEN_PROGRAM_ID,
       })
@@ -1464,6 +1465,7 @@ export class MonacoMarket {
       .moveMarketMatchingPoolToInplay()
       .accounts({
         market: this.pk,
+        marketMatchingQueue: this.matchingQueuePk,
         marketMatchingPool,
       })
       .rpc()

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -187,6 +187,10 @@ export class Monaco {
       marketOrderRequestQueuePk,
     );
 
+    if (marketOrderRequestQueue.orderRequests.len == 0) {
+      return null;
+    }
+
     const front = marketOrderRequestQueue.orderRequests.front;
     const orderRequest = marketOrderRequestQueue.orderRequests.items[front];
 
@@ -196,6 +200,7 @@ export class Monaco {
       forOutcome: orderRequest.forOutcome,
       marketOutcomeIndex: orderRequest.marketOutcomeIndex,
       expectedPrice: orderRequest.expectedPrice,
+      delayExpirationTimestamp: orderRequest.delayExpirationTimestamp,
     };
   }
 
@@ -207,6 +212,10 @@ export class Monaco {
     const marketMatchingQueue = await this.fetchMarketMatchingQueue(
       marketMatchingQueuePk,
     );
+
+    if (marketMatchingQueue.matches.len == 0) {
+      return null;
+    }
 
     const matchesFront = marketMatchingQueue.matches.front;
     const matchesHead = marketMatchingQueue.matches.items[matchesFront];
@@ -232,6 +241,10 @@ export class Monaco {
     const marketMatchingPool = await this.fetchMarketMatchingPool(
       marketMatchingPoolPk,
     );
+
+    if (marketMatchingPool.orders.len == 0) {
+      return null;
+    }
 
     const ordersFront = marketMatchingPool.orders.front;
     return marketMatchingPool.orders.items[ordersFront];
@@ -1133,6 +1146,9 @@ export class MonacoMarket {
 
   async processMatchingQueue(crankOperatorKeypair?: Keypair) {
     const takerOrder = await this.getMarketMatchingQueueHead();
+    if (takerOrder == null) {
+      return;
+    }
 
     const matchingPools =
       this.matchingPools[takerOrder.outcomeIndex][takerOrder.price];
@@ -1427,6 +1443,7 @@ export class MonacoMarket {
       .moveMarketToInplay()
       .accounts({
         market: this.pk,
+        marketLiquidities: this.liquiditiesPk,
       })
       .rpc()
       .catch((e) => {


### PR DESCRIPTION
includes commit from #179 

When a market that is configured to zero the orderbook at event start a number of accounts need to be updated and some of this handling was missed with the introduction of order requests and the market liquidity account. 

Market Liquidities need to be reset. 
Market matching pools (MMPs) need to be set to length zero and liquidity totals set to zero. 
Market needs its flag set to true. 

This PR ties resetting the MarketLiquidities account to setting the `inplay` flag on `Market`. This ensures liquidities are only reset once. MMPs already have a flag. 

There are trustless instructions to trigger all of these actions. 

We also have to consider if market/liquidity interactions occur before some or all of these instructions are triggered. The three interactions to consider are order creation (processing an order request), trusted order cancellation, and/or the trustless cancelling of preplay orders after event start for markets configured to allow this. 

1. Process Order Request - If the event has started but the market and liquidities have not been updated then do so. And/or update the MMP for the given order parameters. This order will end up in the MMP fully unmatched as liquidities have been zerod. Any opposite MMPs will be updated either trustlessly or by another interaction. 

2. Trusted order cancellation - A order can be cancelled before any transition occurs, after market and liquidities are update, or after MMP is transitioned. As such, if found to be so, cancel order will update market and zero liquidities. It will update the MMP if required. And the order's unmatched liquidity will only be removed from the market liquidity totals if the order was found to be on the MMPs order queue. If it isn't on the queue, then the order must have been dropped after the transition and its liquidity is no longer counted towards available totals. 

3. Trustless order cancellation - This can only occur after event start, and for markets configured for such behaviour. Just for completeness, this instruction will also transition any of market, liquidities and MMP to inplay as required. The order being cancelled has no effect on liquidity totals. 