### PR TITLE
fix: removing accounts that were droped from the endpoint

### DIFF
--- a/tests/market/create_market.ts
+++ b/tests/market/create_market.ts
@@ -7,11 +7,6 @@ import assert from "assert";
 import { findEscrowPda, findMarketPda } from "../../npm-client/src/";
 import { createNewMint, createWalletWithBalance } from "../util/test_util";
 import { Monaco, monaco } from "../util/wrappers";
-import {
-  findCommissionPaymentsQueuePda,
-  findOrderRequestQueuePda,
-  findMarketMatchingQueuePda,
-} from "../../npm-admin-client";
 import { getOrCreateMarketType } from "../../npm-admin-client/src/market_type_create";
 
 describe("Create markets with inplay features", () => {
@@ -142,12 +137,6 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
 
     await monaco.program.methods
       .createMarket(
@@ -168,8 +157,6 @@ describe("Market: creation", () => {
         market: marketPk,
         marketType: marketTypePk,
         escrow: marketEscrowPk,
-        matchingQueue: matchingQueuePk,
-        commissionPaymentQueue: marketPaymentQueuePk,
         mint: mintPk,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
         authorisedOperators: authorisedOperatorsPk,
@@ -227,12 +214,6 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
 
     try {
       await monaco.program.methods
@@ -254,8 +235,6 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
-          matchingQueue: matchingQueuePk,
-          commissionPaymentQueue: marketPaymentQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
           authorisedOperators: authorisedOperatorsPk,
@@ -320,16 +299,6 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-
-    const orderRequestQueuePk = (
-      await findOrderRequestQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
 
     try {
       await monaco.program.methods
@@ -351,9 +320,6 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
-          matchingQueue: matchingQueuePk,
-          commissionPaymentQueue: marketPaymentQueuePk,
-          orderRequestQueue: orderRequestQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
           authorisedOperators: authorisedOperatorsPk,
@@ -418,12 +384,6 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
 
     try {
       await monaco.program.methods
@@ -445,8 +405,6 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
-          matchingQueue: matchingQueuePk,
-          commissionPaymentQueue: marketPaymentQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
           authorisedOperators: authorisedOperatorsPk,
@@ -512,16 +470,6 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-
-    const orderRequestQueuePk = (
-      await findOrderRequestQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
 
     try {
       await monaco.program.methods
@@ -543,9 +491,6 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
-          matchingQueue: matchingQueuePk,
-          commissionPaymentQueue: marketPaymentQueuePk,
-          orderRequestQueue: orderRequestQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
           authorisedOperators: authorisedOperatorsPk,
@@ -607,15 +552,7 @@ describe("Market: creation", () => {
     const marketEscrowPk = (
       await findEscrowPda(monaco.program as Program, marketPk)
     ).data.pda;
-    const matchingQueuePk = (
-      await findMarketMatchingQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const marketPaymentQueuePk = (
-      await findCommissionPaymentsQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
-    const orderRequestQueuePk = (
-      await findOrderRequestQueuePda(monaco.program as Program, marketPk)
-    ).data.pda;
+
     try {
       await monaco.program.methods
         .createMarket(
@@ -636,9 +573,6 @@ describe("Market: creation", () => {
           market: marketPk,
           marketType: marketTypePk,
           escrow: marketEscrowPk,
-          matchingQueue: matchingQueuePk,
-          commissionPaymentQueue: marketPaymentQueuePk,
-          orderRequestQueue: orderRequestQueuePk,
           mint: mintPk,
           rent: anchor.web3.SYSVAR_RENT_PUBKEY,
           authorisedOperators: authorisedOperatorsPk,


### PR DESCRIPTION
looks like test  for market creation had some accounts passed that are no longer needed