### PR TITLE
fix: process_order_match endpoint validates matching_pool outcome

### DIFF
--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -169,6 +169,8 @@ pub enum CoreError {
     MatchingOrdersForAndAgainstAreIdentical,
     #[msg("Core Matching: market price mismatch")]
     MatchingMarketPriceMismatch,
+    #[msg("Core Matching: market outcome index mismatch")]
+    MatchingMarketOutcomeIndexMismatch,
 
     #[msg("Order Matching: status closed")]
     MatchingStatusClosed,
@@ -186,8 +188,6 @@ pub enum CoreError {
     MatchingQueueIsEmpty,
     #[msg("Matching queue is not empty.")]
     MatchingQueueIsNotEmpty,
-    #[msg("There was an attempt to dequeue an item from a matching pool queue, but the item at the front of the queue was incorrect.")]
-    IncorrectOrderDequeueAttempt,
     #[msg("The order to be matched is not at the front of the matching pool queue")]
     OrderNotAtFrontOfQueue,
     #[msg("Failed to update market: invalid arguments provided.")]
@@ -217,16 +217,13 @@ pub enum CoreError {
     MatchingMarketNotYetInplay,
     #[msg("Matching: invalid market status for operation")]
     MatchingMarketInvalidStatus,
-    // matching queue related errors
     #[msg("Matching: matched stake calculated incorrectly")]
     MatchingMatchedStakeCalculationError,
-    #[msg("Matching: matching queue empty")]
-    MatchingMatchingQueueEmpty,
-    #[msg("Matching: matching queue head mismatch")]
-    MatchingMatchingQueueHeadMismatch,
-    // -------------------
-    #[msg("matching: unknown")]
-    Unknown,
+    // matching pool related errors
+    #[msg("Matching: matching pool empty")]
+    MatchingPoolIsEmpty,
+    #[msg("Matching: matching pool head mismatch")]
+    MatchingPoolHeadMismatch,
 
     /*
     Inplay

--- a/programs/monaco_protocol/src/instructions/matching/on_order_match.rs
+++ b/programs/monaco_protocol/src/instructions/matching/on_order_match.rs
@@ -30,7 +30,7 @@ pub fn on_order_match(
     let now = current_timestamp();
 
     match market_matching_queue.matches.peek_mut() {
-        None => Err(error!(CoreError::MatchingMatchingQueueEmpty)),
+        None => Err(error!(CoreError::MatchingQueueIsEmpty)),
         Some(taker_order) => {
             // determine matched stake
             let stake = maker_order.stake_unmatched.min(taker_order.stake);
@@ -187,7 +187,7 @@ mod test {
         );
         assert!(on_order_match_testable_result.is_err());
         assert_eq!(
-            error!(CoreError::MatchingMatchingQueueEmpty),
+            error!(CoreError::MatchingQueueIsEmpty),
             on_order_match_testable_result.unwrap_err()
         );
 


### PR DESCRIPTION
Release 0.14.0 Audit Issue 1: Missing `outcome_index` check in `process_order_match` endpoint

### Solution

I've opted to add validation to `market_matching_pool` to make sure it matches the outcome of the `market_matching_queue`. By extension it means that the `maker_order` is correct as well.