### PR TITLE
fix: unnecessary market_matching_pool in context

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -348,20 +348,6 @@ pub struct CancelOrderPostMarketLock<'info> {
 
     #[account(mut, address = order.market @ CoreError::CancelationMarketMismatch)]
     pub market: Box<Account<'info, Market>>,
-
-    #[account(
-        mut,
-        seeds = [
-            market.key().as_ref(),
-            order.market_outcome_index.to_string().as_ref(),
-            b"-".as_ref(),
-            format!("{:.3}", order.expected_price).as_ref(),
-            order.for_outcome.to_string().as_ref(),
-        ],
-        bump,
-    )]
-    pub market_matching_pool: Account<'info, MarketMatchingPool>,
-
     #[account(
         mut,
         token::mint = market.mint_account,
@@ -370,7 +356,6 @@ pub struct CancelOrderPostMarketLock<'info> {
         bump,
     )]
     pub market_escrow: Box<Account<'info, TokenAccount>>,
-
     #[account(
         seeds = [b"order_request".as_ref(), market.key().as_ref()],
         bump,

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1130,11 +1130,6 @@ export class MonacoMarket {
   async cancelOrderPostMarketLock(orderPk: PublicKey) {
     const [order] = await Promise.all([this.monaco.fetchOrder(orderPk)]);
     const purchaserTokenPk = await this.cachePurchaserTokenPk(order.purchaser);
-    const matchingPoolPk = order.forOutcome
-      ? this.matchingPools[order.marketOutcomeIndex][order.expectedPrice]
-          .forOutcome
-      : this.matchingPools[order.marketOutcomeIndex][order.expectedPrice]
-          .against;
     await this.monaco.program.methods
       .cancelOrderPostMarketLock()
       .accounts({
@@ -1144,7 +1139,6 @@ export class MonacoMarket {
         purchaserToken: purchaserTokenPk,
         market: this.pk,
         marketEscrow: this.escrowPk,
-        marketMatchingPool: matchingPoolPk,
         orderRequestQueue: this.orderRequestQueuePk,
         matchingQueue: this.matchingQueuePk,
         tokenProgram: TOKEN_PROGRAM_ID,


### PR DESCRIPTION
`CancelOrderPostMarketLock` context contained unnecessary `market_matching_pool`.