### PR TITLE
chore: drop -dev from versions for 0.14.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.0.0-dev",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "10.0.0-dev",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.0.0-dev",
+  "version": "10.0.0",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.0.0-dev",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "11.0.0-dev",
+      "version": "11.0.0",
       "license": "MIT",
       "dependencies": {
         "big.js": "^6.2.1"

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.0.0-dev",
+  "version": "11.0.0",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.14.0-dev"
+version = "0.14.0"
 description = "Created with Anchor"
 edition = "2018"
 


### PR DESCRIPTION
Dropping the `-dev` suffix from TS client and Protocol program versions for release of 0.14.0