### PR TITLE
feat: order request expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.14.0"
+version = "0.14.1-dev"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.0.0",
+  "version": "10.1.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "10.0.0",
+      "version": "10.1.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.0.0",
+  "version": "10.1.0-dev",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/docs/endpoints/create_order_instruction.md
+++ b/npm-client/docs/endpoints/create_order_instruction.md
@@ -54,8 +54,11 @@ but the orderPk returned by this function will match the PDA of the order accoun
 *   `forOutcome` **[boolean][8]** {boolean} whether the order is for or against the outcome
 *   `price` **[number][7]** {number} price at which the order should be created, the price should be present on the outcome pool for the market
 *   `stake` **BN** {BN} raw token value of the order taking into account the decimal amount of the token associated with the market
-*   `priceLadderPk` **PublicKey?** {PublicKey} Optional: publicKey of the price ladder associated with the market outcome - if there is one
-*   `productPk` **PublicKey?** {PublicKey} Optional: publicKey of product account this order was created on
+*   `options` **{priceLadderPk: PublicKey?, productPk: PublicKey?, expiresOn: BN?}**&#x20;
+
+    *   `options.priceLadderPk`  {PublicKey} Optional: publicKey of the price ladder associated with the market outcome - if there is one
+    *   `options.productPk`  {PublicKey} Optional: publicKey of product account this order was created on
+    *   `options.expiresOn`  {BN} Optional: unix timestamp (seconds) defining expiration of request; if omitted or null or undefined order request will never expire
 
 ### Examples
 
@@ -67,7 +70,8 @@ const price = 1.5
 const stake = 20,000,000,000
 const priceLadderPk = new PublicKey('Dopn2C9R4G6GaPwFAxaNWM33D7o1PXyYZtBBDFZf9cEhH')
 const productPk = new PublicKey('yourNewExcHangeZf9cEhHopn2C9R4G6GaPwFAxaNWM33D')
-const instruction = await buildOrderInstruction(program, marketPk, marketOutcomeIndex, forOutcome, price, stake, , productPk)
+const expiresOn = new BN(1010101010101)
+const instruction = await buildOrderInstruction(program, marketPk, marketOutcomeIndex, forOutcome, price, stake, {priceLadderPk, productPk, expiresOn} )
 ```
 
 Returns **OrderInstructionResponse** derived order publicKey and the instruction to perform a create order transaction

--- a/npm-client/docs/types/order.md
+++ b/npm-client/docs/types/order.md
@@ -62,7 +62,7 @@ Type: {purchaser: PublicKey, market: PublicKey, marketOutcomeIndex: [number][26]
 
 ## OrderRequest
 
-Type: {purchaser: PublicKey, marketOutcomeIndex: [number][26], forOutcome: [boolean][27], product: (PublicKey | null), stake: BN, expectedPrice: [number][26], delayExpirationTimestamp: BN, productCommissionRate: [number][26], distinctSeed: [Array][28]<[number][26]>, creationTimestamp: BN}
+Type: {purchaser: PublicKey, marketOutcomeIndex: [number][26], forOutcome: [boolean][27], product: (PublicKey | null), stake: BN, expectedPrice: [number][26], delayExpirationTimestamp: BN, productCommissionRate: [number][26], distinctSeed: [Array][28]<[number][26]>, creationTimestamp: BN, expiresOn: BN}
 
 ### Properties
 
@@ -76,6 +76,7 @@ Type: {purchaser: PublicKey, marketOutcomeIndex: [number][26], forOutcome: [bool
 *   `productCommissionRate` **[number][26]**&#x20;
 *   `distinctSeed` **[Array][28]<[number][26]>**&#x20;
 *   `creationTimestamp` **BN**&#x20;
+*   `expiresOn` **BN**&#x20;
 
 ## OrderInstructionResponse
 

--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.0.0",
+  "version": "11.1.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "11.0.0",
+      "version": "11.1.0-dev",
       "license": "MIT",
       "dependencies": {
         "big.js": "^6.2.1"

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.0.0",
+  "version": "11.1.0-dev",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/src/create_order.ts
+++ b/npm-client/src/create_order.ts
@@ -122,8 +122,10 @@ export async function createOrder(
     forOutcome,
     price,
     stake,
-    priceLadderPk,
-    productPk,
+    {
+      priceLadderPk,
+      productPk,
+    },
   );
 
   response.addResponseData({

--- a/npm-client/types/order.ts
+++ b/npm-client/types/order.ts
@@ -44,6 +44,7 @@ export type OrderRequest = {
   productCommissionRate: number;
   distinctSeed: number[];
   creationTimestamp: BN;
+  expiresOn: BN;
 };
 
 export type OrderInstructionResponse = {

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.14.0"
+version = "0.14.1-dev"
 description = "Created with Anchor"
 edition = "2018"
 

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -36,6 +36,8 @@ pub enum CoreError {
     CreationMarketMismatch,
     #[msg("Order Creation: purchaser mismatch")]
     CreationPurchaserMismatch,
+    #[msg("Order Creation: expired")]
+    CreationExpired,
 
     #[msg("Order Request Creation: request queue is full")]
     OrderRequestCreationQueueFull,

--- a/programs/monaco_protocol/src/instructions/market_position/update_on_order_match.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/update_on_order_match.rs
@@ -92,7 +92,7 @@ pub fn update_on_order_match(
 mod tests {
     use super::*;
     use crate::instructions::market_position;
-    use crate::state::market_order_request_queue::OrderRequest;
+    use crate::state::market_order_request_queue::{mock_order_request, OrderRequest};
     use test_case::test_case;
 
     struct OrderData {
@@ -228,9 +228,10 @@ mod tests {
         let mut market_position = market_position(vec![0_i128; 3], vec![0_u64; 3]);
 
         for order_data in orders.into_vec() {
-            let order_request = order_request(
-                order_data.outcome_index as u16,
+            let order_request = mock_order_request(
+                Pubkey::new_unique(),
                 order_data.for_outcome,
+                order_data.outcome_index as u16,
                 order_data.stake,
                 order_data.price,
             );
@@ -274,26 +275,6 @@ mod tests {
             payout: 0u64,
             payer: Pubkey::new_unique(),
             product_commission_rate: 0f64,
-        }
-    }
-
-    fn order_request(
-        market_outcome_index: u16,
-        for_outcome: bool,
-        stake: u64,
-        expected_price: f64,
-    ) -> OrderRequest {
-        OrderRequest {
-            purchaser: Default::default(),
-            market_outcome_index,
-            for_outcome,
-            product: None,
-            stake,
-            expected_price,
-            delay_expiration_timestamp: 0,
-            product_commission_rate: 0f64,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
         }
     }
 

--- a/programs/monaco_protocol/src/instructions/matching/on_order_match.rs
+++ b/programs/monaco_protocol/src/instructions/matching/on_order_match.rs
@@ -113,7 +113,7 @@ pub fn on_order_match(
 
 #[cfg(test)]
 mod test {
-    use crate::state::market_order_request_queue::OrderRequest;
+    use crate::state::market_order_request_queue::{mock_order_request, OrderRequest};
     use crate::state::{
         market_account::{MarketOrderBehaviour, MarketStatus},
         market_matching_pool_account::Cirque,
@@ -427,27 +427,6 @@ mod test {
             escrow_account_bump: 0,
             funding_account_bump: 0,
             event_start_timestamp: 100,
-        }
-    }
-
-    fn mock_order_request(
-        purchaser: Pubkey,
-        for_outcome: bool,
-        outcome: u16,
-        stake: u64,
-        price: f64,
-    ) -> OrderRequest {
-        OrderRequest {
-            purchaser,
-            market_outcome_index: outcome,
-            for_outcome,
-            stake,
-            expected_price: price,
-            product: None,
-            product_commission_rate: 0.0,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
         }
     }
 

--- a/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
@@ -63,7 +63,7 @@ pub fn cancel_order_post_market_lock(
 mod test {
     use crate::state::market_account::MarketStatus;
     use crate::state::market_matching_queue_account::{mock_market_matching_queue, OrderMatch};
-    use crate::state::market_order_request_queue::{mock_order_request_queue, OrderRequest};
+    use crate::state::market_order_request_queue::{mock_order_request, mock_order_request_queue};
     use crate::state::order_account::OrderStatus;
 
     use super::*;
@@ -71,18 +71,7 @@ mod test {
     #[test]
     fn error_market_queues_not_empty() {
         let mut market = mock_market();
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -166,18 +155,7 @@ mod test {
     #[test]
     fn error_market_status_invalid() {
         let mut market = mock_market();
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -229,18 +207,7 @@ mod test {
     #[test]
     fn error_market_not_locked() {
         let mut market = mock_market();
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -292,18 +259,7 @@ mod test {
     #[test]
     fn error_market_not_configured_to_cancel() {
         let mut market = mock_market();
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -355,18 +311,7 @@ mod test {
     #[test]
     fn error_order_status_invalid() {
         let mut market = mock_market();
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -420,18 +365,7 @@ mod test {
     fn ok_cancel_remaining_unmatched_stake() {
         let mut market = mock_market();
         market.unsettled_accounts_count = 1;
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),
@@ -501,18 +435,7 @@ mod test {
     fn ok_cancel_all_stake() {
         let mut market = mock_market();
         market.unsettled_accounts_count = 1;
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 1,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), false, 1, 100_u64, 2.4_f64);
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
             market: Pubkey::new_unique(),

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -85,7 +85,7 @@ mod test {
     use crate::state::market_liquidities::mock_market_liquidities;
     use crate::state::market_matching_pool_account::Cirque;
     use crate::state::market_matching_queue_account::{mock_market_matching_queue, OrderMatch};
-    use crate::state::market_order_request_queue::{mock_order_request_queue, OrderRequest};
+    use crate::state::market_order_request_queue::{mock_order_request, mock_order_request_queue};
     use crate::state::order_account::OrderStatus;
 
     use super::*;
@@ -101,18 +101,13 @@ mod test {
 
         let mut market_liquidities = mock_market_liquidities(market_pk);
 
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
+        let order_request = mock_order_request(
+            Pubkey::new_unique(),
+            false,
             market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+            100_u64,
+            2.4_f64,
+        );
 
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
@@ -179,18 +174,13 @@ mod test {
         let mut market_liquidities = mock_market_liquidities(market_pk);
         let mut market_position = mock_market_position(3);
 
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
+        let order_request = mock_order_request(
+            Pubkey::new_unique(),
+            false,
             market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+            100_u64,
+            2.4_f64,
+        );
 
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
@@ -277,18 +267,14 @@ mod test {
         let mut market = mock_market();
         let mut market_liquidities = mock_market_liquidities(market_pk);
 
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
+        let mut order_request = mock_order_request(
+            Pubkey::new_unique(),
+            false,
             market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: market.event_start_timestamp + 1,
-        };
+            100_u64,
+            2.4_f64,
+        );
+        order_request.creation_timestamp = market.event_start_timestamp + 1;
 
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
@@ -352,18 +338,13 @@ mod test {
         let mut market = mock_market();
         let mut market_liquidities = mock_market_liquidities(market_pk);
 
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
+        let order_request = mock_order_request(
+            Pubkey::new_unique(),
+            false,
             market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 99,
-        };
+            100_u64,
+            2.4_f64,
+        );
 
         let mut order = Order {
             purchaser: Pubkey::new_unique(),
@@ -430,18 +411,13 @@ mod test {
         let mut market = mock_market();
         let mut market_liquidities = mock_market_liquidities(market_pk);
 
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
+        let order_request = mock_order_request(
+            Pubkey::new_unique(),
+            false,
             market_outcome_index,
-            for_outcome: false,
-            product: None,
-            product_commission_rate: 0.0,
-            expected_price: 2.4_f64,
-            stake: 100_u64,
-            delay_expiration_timestamp: 0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 99,
-        };
+            100_u64,
+            2.4_f64,
+        );
 
         let mut order = Order {
             purchaser: Pubkey::new_unique(),

--- a/programs/monaco_protocol/src/instructions/order_request/create_order_request.rs
+++ b/programs/monaco_protocol/src/instructions/order_request/create_order_request.rs
@@ -88,6 +88,7 @@ fn initialize_order_request(
     }?;
     order_request.distinct_seed = data.distinct_seed;
     order_request.creation_timestamp = now;
+    order_request.expires_on = data.expires_on;
 
     match product {
         Some(product_account) => {
@@ -112,6 +113,9 @@ fn validate_order_request(
 ) -> Result<()> {
     validate_market_for_order_request(market, now)?;
 
+    if let Some(expires_on) = data.expires_on {
+        require!(expires_on > now, CoreError::CreationExpired);
+    }
     require!(data.stake > 0_u64, CoreError::CreationStakeZeroOrLess);
     require!(data.price > 1_f64, CoreError::CreationPriceOneOrLess);
     let stake_precision_check_result =
@@ -208,6 +212,7 @@ mod tests {
             stake: 100000_u64,
             price: 2.1111_f64,
             distinct_seed: [0_u8; 16],
+            expires_on: None,
         };
 
         let result =

--- a/programs/monaco_protocol/src/instructions/order_request/dequeue_order_request.rs
+++ b/programs/monaco_protocol/src/instructions/order_request/dequeue_order_request.rs
@@ -25,23 +25,12 @@ pub fn dequeue_order_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::market_order_request_queue::{OrderRequest, OrderRequestQueue};
+    use crate::state::market_order_request_queue::{mock_order_request, OrderRequestQueue};
 
     #[test]
     fn dequeue_order_request_ok() {
         let purchaser = Pubkey::new_unique();
-        let order_request = OrderRequest {
-            purchaser,
-            market_outcome_index: 0,
-            for_outcome: true,
-            product: None,
-            stake: 10,
-            expected_price: 3.0,
-            delay_expiration_timestamp: 0,
-            product_commission_rate: 0.0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(purchaser, true, 0, 10_u64, 3.0_f64);
         let expected_refund = order_request.stake;
 
         let order_request_queue = &mut MarketOrderRequestQueue {
@@ -68,18 +57,7 @@ mod tests {
 
     #[test]
     fn dequeue_order_request_purchaser_mismatch() {
-        let order_request = OrderRequest {
-            purchaser: Pubkey::new_unique(),
-            market_outcome_index: 0,
-            for_outcome: true,
-            product: None,
-            stake: 10,
-            expected_price: 3.0,
-            delay_expiration_timestamp: 0,
-            product_commission_rate: 0.0,
-            distinct_seed: [0; 16],
-            creation_timestamp: 0,
-        };
+        let order_request = mock_order_request(Pubkey::new_unique(), true, 0, 10_u64, 3.0_f64);
 
         let order_request_queue = &mut MarketOrderRequestQueue {
             market: Pubkey::new_unique(),

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -116,7 +116,7 @@ pub mod monaco_protocol {
             &mut ctx.accounts.market,
             &mut ctx.accounts.market_liquidities,
             &mut ctx.accounts.market_matching_queue,
-            ctx.accounts.crank_operator.key(),
+            &ctx.accounts.crank_operator,
             &mut ctx.accounts.market_matching_pool,
             &mut ctx.accounts.order_request_queue,
         )?;

--- a/programs/monaco_protocol/src/state/market_order_request_queue.rs
+++ b/programs/monaco_protocol/src/state/market_order_request_queue.rs
@@ -28,6 +28,7 @@ pub struct OrderRequest {
     pub product_commission_rate: f64, // product commission rate at time of order creation
     pub distinct_seed: [u8; 16],      // used as a seed for generating a unique order pda
     pub creation_timestamp: i64,      // timestamp when request was created
+    pub expires_on: Option<i64>,      // timestamp when request is supposed to expire if set
 }
 
 impl OrderRequest {
@@ -39,7 +40,8 @@ impl OrderRequest {
     + (F64_SIZE * 2) // expected_price & product_commission_rate
     + I64_SIZE // delay_expiration_timestamp
     + U128_SIZE // distinct_seed
-    + I64_SIZE; // creation_timestamp
+    + I64_SIZE // creation_timestamp
+    + option_size(I64_SIZE); // expire_on
 
     pub fn new_unique() -> Self {
         OrderRequest {
@@ -53,6 +55,7 @@ impl OrderRequest {
             product_commission_rate: 0.0,
             distinct_seed: [0; 16],
             creation_timestamp: 0,
+            expires_on: None,
         }
     }
 }
@@ -64,6 +67,7 @@ pub struct OrderRequestData {
     pub stake: u64,
     pub price: f64,
     pub distinct_seed: [u8; 16],
+    pub expires_on: Option<i64>,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone)]
@@ -181,6 +185,29 @@ pub fn mock_order_request_queue(market_pk: Pubkey) -> MarketOrderRequestQueue {
     MarketOrderRequestQueue {
         market: market_pk,
         order_requests: OrderRequestQueue::new(1),
+    }
+}
+
+#[cfg(test)]
+pub fn mock_order_request(
+    purchaser: Pubkey,
+    for_outcome: bool,
+    outcome: u16,
+    stake: u64,
+    price: f64,
+) -> OrderRequest {
+    OrderRequest {
+        purchaser,
+        market_outcome_index: outcome,
+        for_outcome,
+        stake,
+        expected_price: price,
+        product: None,
+        product_commission_rate: 0.0,
+        delay_expiration_timestamp: 0,
+        distinct_seed: [0; 16],
+        creation_timestamp: 0,
+        expires_on: None,
     }
 }
 
@@ -348,6 +375,7 @@ mod tests {
             expected_price: 0.0,
             product_commission_rate: 0.0,
             creation_timestamp: 0,
+            expires_on: None,
         };
 
         let request_2 = OrderRequest {
@@ -363,6 +391,7 @@ mod tests {
             expected_price: 0.0,
             product_commission_rate: 0.0,
             creation_timestamp: 0,
+            expires_on: None,
         };
         assert_eq!(request_1, request_2);
 
@@ -379,6 +408,7 @@ mod tests {
             expected_price: 0.0,
             product_commission_rate: 0.0,
             creation_timestamp: 0,
+            expires_on: None,
         };
         assert_ne!(request_1, request_3);
     }

--- a/tests/orderRequest/processOrderRequest.ts
+++ b/tests/orderRequest/processOrderRequest.ts
@@ -35,6 +35,7 @@ describe("Order Request Processing", () => {
         market.orderRequestQueuePk,
       )) as OrderRequestQueueAccount;
     assert.equal(orderRequestQueue.orderRequests.len, 1);
+    assert.equal(await market.getTokenBalance(purchaser), 990);
 
     const orderPk = await market.processNextOrderRequest();
 
@@ -44,6 +45,7 @@ describe("Order Request Processing", () => {
         market.orderRequestQueuePk,
       )) as OrderRequestQueueAccount;
     assert.equal(orderRequestQueue.orderRequests.len, 0);
+    assert.equal(await market.getTokenBalance(purchaser), 990);
 
     // ensure order account matches the order request spec
     const order = await monaco.program.account.order.fetch(orderPk);
@@ -58,6 +60,68 @@ describe("Order Request Processing", () => {
       orderRequestPrice,
     );
     assert.equal(matchingPool.liquidity, order.stake.toNumber() / 10 ** 6);
+  });
+
+  it("process expired order request", async function () {
+    const nowUnixTimestamp: number = Math.floor(new Date().getTime() / 1000);
+    const prices = [3.0, 4.9];
+
+    const orderRequestOutcomeIndex = 0;
+    const orderRequestStake = 10.0;
+    const orderRequestPrice = 3.0;
+    const orderRequestForOutcome = true;
+
+    const [purchaser, market] = await Promise.all([
+      createWalletWithBalance(monaco.provider),
+      monaco.create3WayMarket(prices),
+    ]);
+    await market.airdrop(purchaser, 1000.0);
+
+    await market._createOrderRequest(
+      orderRequestOutcomeIndex,
+      orderRequestForOutcome,
+      orderRequestStake,
+      orderRequestPrice,
+      purchaser,
+      {
+        expiresOn: nowUnixTimestamp - 1,
+      },
+    );
+
+    // queue should have 1 unprocessed order
+    let orderRequestQueue =
+      (await monaco.program.account.marketOrderRequestQueue.fetch(
+        market.orderRequestQueuePk,
+      )) as OrderRequestQueueAccount;
+    assert.equal(orderRequestQueue.orderRequests.len, 1);
+    assert.equal(await market.getTokenBalance(purchaser), 990);
+
+    const orderPk = await market.processNextOrderRequest();
+
+    // queue should have 0 unprocessed orders
+    orderRequestQueue =
+      (await monaco.program.account.marketOrderRequestQueue.fetch(
+        market.orderRequestQueuePk,
+      )) as OrderRequestQueueAccount;
+    assert.equal(orderRequestQueue.orderRequests.len, 0);
+    assert.equal(await market.getTokenBalance(purchaser), 1000);
+
+    // ensure order account matches the order request spec
+    try {
+      await monaco.fetchOrder(orderPk);
+      assert.fail("Account should not exist");
+    } catch (e) {
+      assert.equal(
+        e.message,
+        "Account does not exist or has no data " + orderPk,
+      );
+    }
+
+    const matchingPool = await market.getForMatchingPool(
+      orderRequestOutcomeIndex,
+      orderRequestPrice,
+    );
+    assert.equal(matchingPool.liquidity, 0);
   });
 
   it("process order request - inplay market, success if delay has passed", async function () {

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -917,6 +917,7 @@ export class MonacoMarket {
       marketOutcome?: PublicKey;
       productPk?: PublicKey;
       purchaserToken?: PublicKey;
+      expiresOn?: number;
     },
   ) {
     const orderPk = await findOrderPda(
@@ -931,6 +932,7 @@ export class MonacoMarket {
         stake: new BN(this.toAmountInteger(stake)),
         price: price,
         distinctSeed: Array.from(orderPk.data.distinctSeed),
+        expiresOn: overrides.expiresOn ? new BN(overrides.expiresOn) : null,
       })
       .accounts({
         reservedOrder: orderPk.data.orderPk,


### PR DESCRIPTION
Introducing `expiresOn` optional property during creation of order request. If set the value is evaluated:
- firstly on creation where stops adding request if transaction is processed late
- secondly on processing where stops order being created and all funds taken during creation being refunded