### PR TITLE
chore: queue client fixes and improvements 

### DIFF
--- a/npm-admin-client/package-lock.json
+++ b/npm-admin-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/admin-client",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/bs58": "^4.0.1",

--- a/npm-admin-client/package.json
+++ b/npm-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/admin-client",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Admin interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/npm-client/package-lock.json
+++ b/npm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@monaco-protocol/client",
-      "version": "11.2.0",
+      "version": "11.2.1",
       "license": "MIT",
       "dependencies": {
         "big.js": "^6.2.1"

--- a/npm-client/package.json
+++ b/npm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monaco-protocol/client",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "description": "Interface package for the Monaco Protocol on Solana",
   "author": "Monaco Protocol",
   "license": "MIT",

--- a/tests/npm-client/market_commission_payment_queue.ts
+++ b/tests/npm-client/market_commission_payment_queue.ts
@@ -41,6 +41,10 @@ describe("Market Commission Payment Queue", () => {
       monaco.program,
       queuePda.data.pda,
     );
+    // there's an object transformation happening so property needs to be checked
+    expect(queue1.data.account).toHaveProperty("commissionPayments");
+    expect(queue1.data.account).not.toHaveProperty("paymentQueue");
+
     assert.deepEqual(
       queue1.data.account.market.toBase58(),
       market.pk.toBase58(),
@@ -112,6 +116,14 @@ describe("Market Commission Payment Queue", () => {
         .length,
       2,
     );
+
+    // there's an object transformation happening so property needs to be checked
+    expect(
+      queues1.data.marketCommissionPaymentQueues[0].account,
+    ).toHaveProperty("commissionPayments");
+    expect(
+      queues1.data.marketCommissionPaymentQueues[0].account,
+    ).not.toHaveProperty("paymentQueue");
 
     await market1.processCommissionPayments();
 

--- a/tests/npm-client/market_matching_queue.ts
+++ b/tests/npm-client/market_matching_queue.ts
@@ -3,11 +3,13 @@ import {
   findMarketMatchingQueuePda,
   GetAccount,
   getMarketMatchingQueue,
+  getNonEmptyMarketMatchingQueuePks,
   getNonEmptyMarketMatchingQueues,
   MarketMatchingQueue,
 } from "../../npm-client";
 import { monaco } from "../util/wrappers";
 import { createWalletWithBalance } from "../util/test_util";
+import { PublicKey } from "@solana/web3.js";
 
 describe("Market Matching Queue", () => {
   it("fetch by public-key", async () => {
@@ -71,30 +73,41 @@ describe("Market Matching Queue", () => {
     await market2.againstOrder(0, 10, 3.0, purchaser);
 
     // need to filter markets as markets from other parallel tests are reported too
-    const marketPkStrings = [market1.pk.toBase58(), market2.pk.toBase58()];
-    const marketPkStringsCheck = (a: GetAccount<MarketMatchingQueue>) =>
-      marketPkStrings.includes(a.account.market.toBase58());
+    const queuePkStrings = [
+      market1.matchingQueuePk.toBase58(),
+      market2.matchingQueuePk.toBase58(),
+    ];
+    const pkStringsCheck = (a: GetAccount<MarketMatchingQueue>) =>
+      queuePkStrings.includes(a.publicKey.toBase58());
+    const pkStringsCheck2 = (a: PublicKey) =>
+      queuePkStrings.includes(a.toBase58());
 
     const queues1 = await getNonEmptyMarketMatchingQueues(monaco.program);
     assert.equal(
-      queues1.data.marketMatchingQueues.filter(marketPkStringsCheck).length,
+      queues1.data.marketMatchingQueues.filter(pkStringsCheck).length,
       2,
     );
+    const pks1 = await getNonEmptyMarketMatchingQueuePks(monaco.program);
+    assert.equal(pks1.data.publicKeys.filter(pkStringsCheck2).length, 2);
 
     await market1.processMatchingQueue();
 
     const queues2 = await getNonEmptyMarketMatchingQueues(monaco.program);
     assert.equal(
-      queues2.data.marketMatchingQueues.filter(marketPkStringsCheck).length,
+      queues2.data.marketMatchingQueues.filter(pkStringsCheck).length,
       1,
     );
+    const pks2 = await getNonEmptyMarketMatchingQueuePks(monaco.program);
+    assert.equal(pks2.data.publicKeys.filter(pkStringsCheck2).length, 1);
 
     await market2.processMatchingQueue();
 
     const queues3 = await getNonEmptyMarketMatchingQueues(monaco.program);
     assert.equal(
-      queues3.data.marketMatchingQueues.filter(marketPkStringsCheck).length,
+      queues3.data.marketMatchingQueues.filter(pkStringsCheck).length,
       0,
     );
+    const pks3 = await getNonEmptyMarketMatchingQueuePks(monaco.program);
+    assert.equal(pks3.data.publicKeys.filter(pkStringsCheck2).length, 0);
   });
 });

--- a/tests/npm-client/market_order_request_queue.ts
+++ b/tests/npm-client/market_order_request_queue.ts
@@ -3,11 +3,13 @@ import {
   findMarketOrderRequestQueuePda,
   GetAccount,
   getMarketOrderRequestQueue,
+  getNonEmptyMarketOrderRequestQueuePks,
   getNonEmptyMarketOrderRequestQueues,
   MarketOrderRequestQueue,
 } from "../../npm-client";
 import { monaco } from "../util/wrappers";
 import { createWalletWithBalance } from "../util/test_util";
+import { PublicKey } from "@solana/web3.js";
 
 describe("Market Order Request Queue", () => {
   it("fetch by public-key", async () => {
@@ -71,30 +73,41 @@ describe("Market Order Request Queue", () => {
     await market2.againstOrderRequest(0, 10, 3.0, purchaser);
 
     // need to filter markets as markets from other parallel tests are reported too
-    const marketPkStrings = [market1.pk.toBase58(), market2.pk.toBase58()];
-    const marketPkStringsCheck = (a: GetAccount<MarketOrderRequestQueue>) =>
-      marketPkStrings.includes(a.account.market.toBase58());
+    const queuePkStrings = [
+      market1.orderRequestQueuePk.toBase58(),
+      market2.orderRequestQueuePk.toBase58(),
+    ];
+    const pkStringsCheck = (a: GetAccount<MarketOrderRequestQueue>) =>
+      queuePkStrings.includes(a.publicKey.toBase58());
+    const pkStringsCheck2 = (a: PublicKey) =>
+      queuePkStrings.includes(a.toBase58());
 
     const queues1 = await getNonEmptyMarketOrderRequestQueues(monaco.program);
     assert.equal(
-      queues1.data.marketOrderRequestQueues.filter(marketPkStringsCheck).length,
+      queues1.data.marketOrderRequestQueues.filter(pkStringsCheck).length,
       2,
     );
+    const pks1 = await getNonEmptyMarketOrderRequestQueuePks(monaco.program);
+    assert.equal(pks1.data.publicKeys.filter(pkStringsCheck2).length, 2);
 
     await market1.processOrderRequests();
 
     const queues2 = await getNonEmptyMarketOrderRequestQueues(monaco.program);
     assert.equal(
-      queues2.data.marketOrderRequestQueues.filter(marketPkStringsCheck).length,
+      queues2.data.marketOrderRequestQueues.filter(pkStringsCheck).length,
       1,
     );
+    const pks2 = await getNonEmptyMarketOrderRequestQueuePks(monaco.program);
+    assert.equal(pks2.data.publicKeys.filter(pkStringsCheck2).length, 1);
 
     await market2.processOrderRequests();
 
     const queues3 = await getNonEmptyMarketOrderRequestQueues(monaco.program);
     assert.equal(
-      queues3.data.marketOrderRequestQueues.filter(marketPkStringsCheck).length,
+      queues3.data.marketOrderRequestQueues.filter(pkStringsCheck).length,
       0,
     );
+    const pks3 = await getNonEmptyMarketOrderRequestQueuePks(monaco.program);
+    assert.equal(pks3.data.publicKeys.filter(pkStringsCheck2).length, 0);
   });
 });


### PR DESCRIPTION
Change fixes the the issue of property translation for Commission Payments. Additionally it adds to all the queues method fetching pks only.
