### PR TITLE
chore: introducing check for number of outcomes to enable cross matching

### DIFF
--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -296,6 +296,8 @@ pub enum CoreError {
     VoidMarketNotInitializingOrOpen,
     #[msg("Market: cannot open market, must have more than 1 outcome")]
     OpenMarketNotEnoughOutcomes,
+    #[msg("Market: too many outcomes for this operation")]
+    MarketTooManyOutcomes,
     #[msg("Market: market is not settled or voided")]
     MarketNotSettledOrVoided,
     #[msg("Market: market is not ready to close")]

--- a/programs/monaco_protocol/src/instructions/market/update_market_status.rs
+++ b/programs/monaco_protocol/src/instructions/market/update_market_status.rs
@@ -28,6 +28,12 @@ pub fn open(
         market.market_outcomes_count > 1,
         CoreError::OpenMarketNotEnoughOutcomes
     );
+    if enable_cross_matching {
+        require!(
+            market.market_outcomes_count < 6,
+            CoreError::MarketTooManyOutcomes
+        );
+    }
 
     intialize_liquidities(liquidities, market_pk, enable_cross_matching)?;
     market.increment_unclosed_accounts_count()?;

--- a/programs/monaco_protocol/src/instructions/math.rs
+++ b/programs/monaco_protocol/src/instructions/math.rs
@@ -181,21 +181,35 @@ mod tests {
 
     #[test]
     fn test_calculate_price_cross() {
-        let cross_price_2way = calculate_price_cross(&vec![3.0_f64]);
-        assert!(cross_price_2way.is_some());
-        assert_eq!(1.5_f64, cross_price_2way.unwrap());
-
         assert!(calculate_price_cross(&vec![3.1_f64]).is_none());
 
-        let cross_price_3way = calculate_price_cross(&vec![2.0_f64, 3.0_f64]);
+        let cross_price_2way = calculate_price_cross(&vec![2.0_f64; 1]);
+        assert!(cross_price_2way.is_some());
+        assert_eq!(2.0_f64, cross_price_2way.unwrap());
+
+        let cross_price_3way = calculate_price_cross(&vec![3.0_f64; 2]);
         assert!(cross_price_3way.is_some());
-        assert_eq!(6.0_f64, cross_price_3way.unwrap());
+        assert_eq!(3.0_f64, cross_price_3way.unwrap());
 
-        let cross_price_4way_1 = calculate_price_cross(&vec![4.0_f64, 4.0_f64, 4.0_f64]);
-        assert!(cross_price_4way_1.is_some());
-        assert_eq!(4.0_f64, cross_price_4way_1.unwrap());
+        let cross_price_4way = calculate_price_cross(&vec![4.0_f64; 3]);
+        assert!(cross_price_4way.is_some());
+        assert_eq!(4.0_f64, cross_price_4way.unwrap());
 
-        assert!(calculate_price_cross(&vec![4.0_f64, 4.0_f64, 5.0_f64]).is_none());
+        let cross_price_5way = calculate_price_cross(&vec![5.0_f64; 4]);
+        assert!(cross_price_5way.is_some());
+        assert_eq!(5.0_f64, cross_price_5way.unwrap());
+
+        let cross_price_6way = calculate_price_cross(&vec![6.0_f64; 5]);
+        assert!(cross_price_6way.is_some());
+        assert_eq!(6.0_f64, cross_price_6way.unwrap());
+
+        let cross_price_7way = calculate_price_cross(&vec![7.0_f64; 6]);
+        assert!(cross_price_7way.is_some());
+        assert_eq!(7.0_f64, cross_price_7way.unwrap());
+
+        let cross_price_8way = calculate_price_cross(&vec![8.0_f64; 7]);
+        assert!(cross_price_8way.is_some());
+        assert_eq!(8.0_f64, cross_price_8way.unwrap());
     }
 
     #[test]

--- a/tests/order/matching_orders_03.ts
+++ b/tests/order/matching_orders_03.ts
@@ -1,0 +1,124 @@
+import assert from "assert";
+import { createWalletWithBalance } from "../util/test_util";
+import { monaco } from "../util/wrappers";
+import { AnchorError } from "@coral-xyz/anchor";
+
+describe("Order Matching: Cross Liquidity A", () => {
+  it("2-way market", async () => {
+    await execute(2);
+  });
+
+  it("3-way market", async () => {
+    await execute(3);
+  });
+
+  it("4-way market", async () => {
+    await execute(4);
+  });
+
+  it("5-way market", async () => {
+    await execute(5);
+  });
+
+  it("6-way market", async () => {
+    await execute(6).then(
+      function (_) {
+        assert.fail("MarketTooManyOutcomes expected");
+      },
+      function (e: AnchorError) {
+        assert.equal(e.error.errorCode.code, "MarketTooManyOutcomes");
+      },
+    );
+  });
+});
+
+async function execute(outcomesCount: number) {
+  const outcomes = "ABCDEFGHIJKL".slice(0, outcomesCount).split("");
+  const outcomesLastIndex = outcomes.length - 1;
+  const makerOutcomes = outcomes.slice(0, outcomesLastIndex);
+
+  // create market and top up purchasers
+  const price = outcomes.length;
+  const market = await monaco.createMarket(
+    outcomes,
+    new Array(outcomes.length).fill(price),
+  );
+  await market.open(true);
+
+  // create purchaser for each outcome
+  const purchasers = await Promise.all(
+    outcomes.map((_) => createWalletWithBalance(monaco.provider)),
+  );
+  await Promise.all(
+    purchasers.map((purchaser) => market.airdrop(purchaser, 10)),
+  );
+
+  // create (n-1) orders to generate cross liquidity
+  const orders = await Promise.all(
+    makerOutcomes.map((_, outcomeIndex) =>
+      market.forOrder(outcomeIndex, 1, price, purchasers[outcomeIndex]),
+    ),
+  );
+  await market.processOrderRequests();
+
+  // update cross liquidity
+  const sourceLiquidities = makerOutcomes.map((_, outcomeIndex) => {
+    return { outcome: outcomeIndex, price };
+  });
+  await market.updateMarketLiquiditiesWithCrossLiquidity(
+    true,
+    sourceLiquidities,
+    { outcome: outcomesLastIndex, price },
+  );
+
+  // validate expected liquidity
+  assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
+    liquiditiesAgainst: [
+      {
+        liquidity: 1,
+        outcome: outcomesLastIndex,
+        price,
+        sources: makerOutcomes.map((_, outcomeIndex) => {
+          return { outcome: outcomeIndex, price };
+        }),
+      },
+    ],
+    liquiditiesFor: makerOutcomes.map((_, outcomeIndex) => {
+      return {
+        liquidity: 1,
+        outcome: outcomeIndex,
+        price,
+        sources: [],
+      };
+    }),
+  });
+
+  // match cross liquidity
+  const orderLast = await market.forOrder(
+    outcomesLastIndex,
+    1,
+    price,
+    purchasers[outcomesLastIndex],
+  );
+  await market.processMatchingQueue();
+
+  // validate expected liquidity
+  assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
+    liquiditiesAgainst: [],
+    liquiditiesFor: [],
+  });
+  assert.deepEqual(await market.getEscrowBalance(), outcomes.length);
+
+  // settle
+  await market.settle(0);
+  await Promise.all(
+    purchasers.map((purchaser) =>
+      market.settleMarketPositionForPurchaser(purchaser.publicKey, false),
+    ),
+  );
+  await Promise.all(orders.map((order) => market.settleOrder(order)));
+  await market.settleOrder(orderLast);
+
+  // validate that only winners commission left in escrow
+  assert.equal(await market.getEscrowBalance(), (outcomes.length - 1) / 10);
+}

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1010,6 +1010,11 @@ export class MonacoMarket {
     const firstOrderRequest = await this.monaco.getMarketOrderRequestQueueHead(
       this.orderRequestQueuePk,
     );
+
+    if (firstOrderRequest === null) {
+      return null;
+    }
+
     const orderPk = (
       await findOrderPda(
         this.monaco.program,
@@ -1060,14 +1065,18 @@ export class MonacoMarket {
   }
 
   async processOrderRequests(): Promise<PublicKey[]> {
-    const marketOrderRequestQueue =
-      await this.monaco.fetchMarketOrderRequestQueue(this.orderRequestQueuePk);
-
     const orderPks: PublicKey[] = [];
-    for (let i = 0; i < marketOrderRequestQueue.orderRequests.len; i++) {
+
+    // chain delays workaround
+    let tryMore = 2;
+    do {
       const orderPk = await this.processNextOrderRequest();
-      orderPks.push(orderPk);
-    }
+      if (orderPk === null) {
+        tryMore--;
+      } else {
+        orderPks.push(orderPk);
+      }
+    } while (tryMore > 0);
 
     return orderPks;
   }


### PR DESCRIPTION
The cross-matching code is written in a way that can handle markets with any number of outcomes. However, the more outcomes there is the more compute units it requires and the worry that transactions start to fail.

So done some testing and looks like at about 7 outcomes standard 20k of compute units is no longer enough on occasion to create orders with cross matching enabled (8 outcomes is 100% failure).

Based on that then I've decided to limit number of outcomes allowed for cross-matching market to 5.

