### PR TITLE
fix: update_market_liquidities_with_cross_liquidity updates

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -624,7 +624,12 @@ pub struct ProcessOrderMatchMaker<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateMarketLiquidities<'info> {
-    #[account(mut)]
+    #[account()]
+    pub market: Account<'info, Market>,
+    #[account(
+        mut,
+        has_one = market @ CoreError::MarketMismatch,
+    )]
     pub market_liquidities: Account<'info, MarketLiquidities>,
 }
 

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -4,10 +4,18 @@ use anchor_lang::prelude::*;
 pub enum CoreError {
     #[msg("Generic: math operation has failed")]
     ArithmeticError,
+
     #[msg("MarketLiquidities: is full")]
     MarketLiquiditiesIsFull,
     #[msg("MarketLiquidities: update error")]
     MarketLiquiditiesUpdateError,
+    #[msg("MarketLiquidities: cross matching disabled")]
+    MarketLiquiditiesCrossMatchingDisabled,
+    #[msg("MarketLiquidities: source_liquidities invalid")]
+    MarketLiquiditiesSourceLiquiditiesInvalid,
+
+    #[msg("Market: mismatch")]
+    MarketMismatch,
 
     /*
     Order Creation

--- a/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
+++ b/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
@@ -22,6 +22,7 @@ pub fn update_market_liquidities_with_cross_liquidity(
     // ensuring that all newly created cross liquidity has sources sorted the same way
     let mut source_liquidities_sorted = source_liquidities.to_vec();
     source_liquidities_sorted.sort_by(|a, b| a.outcome.partial_cmp(&b.outcome).unwrap());
+    source_liquidities_sorted.retain(|v| v.outcome < market.market_outcomes_count);
     source_liquidities_sorted.dedup_by(|a, b| a.outcome == b.outcome);
 
     // making sure there were no duplicates
@@ -91,6 +92,18 @@ mod test {
         assert_eq!(
             Err(error!(CoreError::MarketLiquiditiesSourceLiquiditiesInvalid)),
             result2
+        );
+
+        let result3 = update_market_liquidities_with_cross_liquidity(
+            &market,
+            &mut market_liquidities,
+            true,
+            vec![LiquiditySource::new(1, 3.0), LiquiditySource::new(3, 2.0)], // incorrect outcomes
+        );
+        assert!(result3.is_err());
+        assert_eq!(
+            Err(error!(CoreError::MarketLiquiditiesSourceLiquiditiesInvalid)),
+            result3
         );
 
         assert_eq!(

--- a/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
+++ b/programs/monaco_protocol/src/instructions/market_liquidities/update_market_liquidities_with_cross_liquidity.rs
@@ -1,22 +1,40 @@
 use crate::error::CoreError;
+use crate::state::market_account::Market;
 use crate::state::market_liquidities::{LiquiditySource, MarketLiquidities};
 use anchor_lang::prelude::*;
 
 pub fn update_market_liquidities_with_cross_liquidity(
+    market: &Market,
     market_liquidities: &mut MarketLiquidities,
     source_for_outcome: bool,
     source_liquidities: Vec<LiquiditySource>,
 ) -> Result<()> {
     require!(
         market_liquidities.enable_cross_matching,
-        CoreError::MarketLiquiditiesUpdateError,
+        CoreError::MarketLiquiditiesCrossMatchingDisabled,
+    );
+
+    require!(
+        source_liquidities.len() == (market.market_outcomes_count - 1) as usize,
+        CoreError::MarketLiquiditiesSourceLiquiditiesInvalid,
+    );
+
+    // ensuring that all newly created cross liquidity has sources sorted the same way
+    let mut source_liquidities_sorted = source_liquidities.to_vec();
+    source_liquidities_sorted.sort_by(|a, b| a.outcome.partial_cmp(&b.outcome).unwrap());
+    source_liquidities_sorted.dedup_by(|a, b| a.outcome == b.outcome);
+
+    // making sure there were no duplicates
+    require!(
+        source_liquidities_sorted.len() == source_liquidities.len(),
+        CoreError::MarketLiquiditiesSourceLiquiditiesInvalid,
     );
 
     // provided cross_liquidity.price is valid
     if source_for_outcome {
-        market_liquidities.update_cross_liquidity_against(&source_liquidities);
+        market_liquidities.update_cross_liquidity_against(&source_liquidities_sorted);
     } else {
-        market_liquidities.update_cross_liquidity_for(&source_liquidities);
+        market_liquidities.update_cross_liquidity_for(&source_liquidities_sorted);
     };
 
     Ok(())
@@ -25,10 +43,111 @@ pub fn update_market_liquidities_with_cross_liquidity(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::state::market_account::{mock_market, MarketStatus};
     use crate::state::market_liquidities::{mock_market_liquidities, MarketOutcomePriceLiquidity};
 
     #[test]
+    fn test_source_liquidities_validation() {
+        let mut market = mock_market(MarketStatus::Open);
+        market.market_outcomes_count = 3;
+        let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
+        market_liquidities
+            .add_liquidity_for(0, 2.0, 100_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 3.0, 100_000)
+            .unwrap();
+
+        assert_eq!(
+            vec!((0, 2.0, 100_000), (1, 3.0, 100_000)),
+            liquidities(&market_liquidities.liquidities_for)
+        );
+        assert_eq!(
+            Vec::<(u16, f64, u64)>::new(),
+            liquidities(&market_liquidities.liquidities_against)
+        );
+
+        //------------------------------------------------------------------------------------------
+
+        let result1 = update_market_liquidities_with_cross_liquidity(
+            &market,
+            &mut market_liquidities,
+            true,
+            vec![LiquiditySource::new(0, 2.0)], // missing source
+        );
+        assert!(result1.is_err());
+        assert_eq!(
+            Err(error!(CoreError::MarketLiquiditiesSourceLiquiditiesInvalid)),
+            result1
+        );
+
+        let result2 = update_market_liquidities_with_cross_liquidity(
+            &market,
+            &mut market_liquidities,
+            true,
+            vec![LiquiditySource::new(1, 3.0), LiquiditySource::new(1, 2.0)], // duplicate outcomes
+        );
+        assert!(result2.is_err());
+        assert_eq!(
+            Err(error!(CoreError::MarketLiquiditiesSourceLiquiditiesInvalid)),
+            result2
+        );
+
+        assert_eq!(
+            Vec::<(u16, f64, u64)>::new(),
+            liquidities(&market_liquidities.liquidities_against)
+        );
+    }
+
+    #[test]
+    fn test_source_order_does_not_matter() {
+        let mut market = mock_market(MarketStatus::Open);
+        market.market_outcomes_count = 3;
+        let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
+        market_liquidities
+            .add_liquidity_for(0, 2.0, 100_000)
+            .unwrap();
+        market_liquidities
+            .add_liquidity_for(1, 3.0, 100_000)
+            .unwrap();
+
+        assert_eq!(
+            vec!((0, 2.0, 100_000), (1, 3.0, 100_000)),
+            liquidities(&market_liquidities.liquidities_for)
+        );
+        assert_eq!(
+            Vec::<(u16, f64, u64)>::new(),
+            liquidities(&market_liquidities.liquidities_against)
+        );
+
+        //------------------------------------------------------------------------------------------
+
+        update_market_liquidities_with_cross_liquidity(
+            &market,
+            &mut market_liquidities,
+            true,
+            vec![LiquiditySource::new(0, 2.0), LiquiditySource::new(1, 3.0)],
+        )
+        .expect("update_market_liquidities_with_cross_liquidity failed");
+
+        update_market_liquidities_with_cross_liquidity(
+            &market,
+            &mut market_liquidities,
+            true,
+            vec![LiquiditySource::new(1, 3.0), LiquiditySource::new(0, 2.0)],
+        )
+        .expect("update_market_liquidities_with_cross_liquidity failed");
+
+        assert_eq!(
+            vec!((2, 6.0, 33_000)),
+            liquidities(&market_liquidities.liquidities_against)
+        );
+    }
+
+    #[test]
     fn test_2_way_market() {
+        let mut market = mock_market(MarketStatus::Open);
+        market.market_outcomes_count = 2;
         let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
         market_liquidities.add_liquidity_for(0, 3.0, 1000).unwrap();
         market_liquidities.add_liquidity_for(0, 3.5, 1000).unwrap();
@@ -44,6 +163,7 @@ mod test {
         //------------------------------------------------------------------------------------------
 
         update_market_liquidities_with_cross_liquidity(
+            &market,
             &mut market_liquidities,
             true,
             vec![LiquiditySource::new(0, 3.0)],
@@ -51,6 +171,7 @@ mod test {
         .expect("update_market_liquidities_with_cross_liquidity failed");
 
         update_market_liquidities_with_cross_liquidity(
+            &market,
             &mut market_liquidities,
             true,
             vec![LiquiditySource::new(0, 3.5)],
@@ -58,6 +179,7 @@ mod test {
         .expect("update_market_liquidities_with_cross_liquidity failed");
 
         update_market_liquidities_with_cross_liquidity(
+            &market,
             &mut market_liquidities,
             true,
             vec![LiquiditySource::new(0, 4.125)],
@@ -74,6 +196,8 @@ mod test {
     fn test_3_way_market() {
         // 2.0, 3.0, 6.0
         // 2.1, 3.0, 5.25
+        let mut market = mock_market(MarketStatus::Open);
+        market.market_outcomes_count = 3;
         let mut market_liquidities = mock_market_liquidities(Pubkey::new_unique());
         market_liquidities
             .add_liquidity_for(0, 2.0, 100_000)
@@ -93,12 +217,15 @@ mod test {
         //------------------------------------------------------------------------------------------
 
         update_market_liquidities_with_cross_liquidity(
+            &market,
             &mut market_liquidities,
             true,
             vec![LiquiditySource::new(0, 2.1), LiquiditySource::new(1, 3.0)],
         )
         .expect("update_market_liquidities_with_cross_liquidity failed");
+
         update_market_liquidities_with_cross_liquidity(
+            &market,
             &mut market_liquidities,
             true,
             vec![LiquiditySource::new(0, 2.0), LiquiditySource::new(1, 3.0)],

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -343,6 +343,7 @@ pub mod monaco_protocol {
         source_liquidities: Vec<LiquiditySource>,
     ) -> Result<()> {
         instructions::market_liquidities::update_market_liquidities_with_cross_liquidity(
+            &ctx.accounts.market,
             &mut ctx.accounts.market_liquidities,
             source_for_outcome,
             source_liquidities,

--- a/programs/monaco_protocol/src/lib.rs
+++ b/programs/monaco_protocol/src/lib.rs
@@ -341,13 +341,11 @@ pub mod monaco_protocol {
         ctx: Context<UpdateMarketLiquidities>,
         source_for_outcome: bool,
         source_liquidities: Vec<LiquiditySource>,
-        cross_liquidity: LiquiditySource,
     ) -> Result<()> {
         instructions::market_liquidities::update_market_liquidities_with_cross_liquidity(
             &mut ctx.accounts.market_liquidities,
             source_for_outcome,
             source_liquidities,
-            cross_liquidity,
         )?;
 
         Ok(())

--- a/tests/order/matching_orders_02.ts
+++ b/tests/order/matching_orders_02.ts
@@ -26,14 +26,10 @@ describe("Order Matching: Cross Liquidity", () => {
     const orderB = await market.forOrder(1, 0.009, PRICES[1], purchaserB);
 
     // cross liquidities
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      true,
-      [
-        { outcome: 0, price: PRICES[0] },
-        { outcome: 1, price: PRICES[1] },
-      ],
-      { outcome: 2, price: 3.375 },
-    );
+    await market.updateMarketLiquiditiesWithCrossLiquidity(true, [
+      { outcome: 0, price: PRICES[0] },
+      { outcome: 1, price: PRICES[1] },
+    ]);
 
     // validate expected liquidity
     assert.deepEqual(await monaco.getMarketLiquidities(market.liquiditiesPk), {
@@ -277,14 +273,10 @@ describe("Order Matching: Cross Liquidity", () => {
     const orderB = await market.forOrder(1, 0.009, PRICES[1], purchaserB);
 
     // cross liquidities
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      true,
-      [
-        { outcome: 0, price: PRICES[0] },
-        { outcome: 1, price: PRICES[1] },
-      ],
-      { outcome: 2, price: 3.375 },
-    );
+    await market.updateMarketLiquiditiesWithCrossLiquidity(true, [
+      { outcome: 0, price: PRICES[0] },
+      { outcome: 1, price: PRICES[1] },
+    ]);
 
     // cancel one of the sources
     await market.cancel(orderA, purchaserA);

--- a/tests/protocol/update_market_liquidities_with_cross_liquidity.ts
+++ b/tests/protocol/update_market_liquidities_with_cross_liquidity.ts
@@ -27,16 +27,12 @@ describe("Protocol: Cross Liquidity", () => {
     );
 
     // When
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      true,
-      [{ outcome: 0, price: 1.5 }],
-      { outcome: 1, price: 3.0 },
-    );
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      false,
-      [{ outcome: 1, price: 1.5 }],
-      { outcome: 0, price: 3.0 },
-    );
+    await market.updateMarketLiquiditiesWithCrossLiquidity(true, [
+      { outcome: 0, price: 1.5 },
+    ]);
+    await market.updateMarketLiquiditiesWithCrossLiquidity(false, [
+      { outcome: 1, price: 1.5 },
+    ]);
 
     // Then
     assert.deepEqual(await market.getMarketLiquidities(), {
@@ -86,22 +82,14 @@ describe("Protocol: Cross Liquidity", () => {
     );
 
     // When
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      true,
-      [
-        { outcome: 0, price: 2.1 },
-        { outcome: 1, price: 3.0 },
-      ],
-      { outcome: 2, price: 5.25 },
-    );
-    await market.updateMarketLiquiditiesWithCrossLiquidity(
-      false,
-      [
-        { outcome: 1, price: 2.1 },
-        { outcome: 2, price: 3.0 },
-      ],
-      { outcome: 0, price: 5.25 },
-    );
+    await market.updateMarketLiquiditiesWithCrossLiquidity(true, [
+      { outcome: 0, price: 2.1 },
+      { outcome: 1, price: 3.0 },
+    ]);
+    await market.updateMarketLiquiditiesWithCrossLiquidity(false, [
+      { outcome: 1, price: 2.1 },
+      { outcome: 2, price: 3.0 },
+    ]);
 
     // Then
     assert.deepEqual(await market.getMarketLiquidities(), {

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1075,13 +1075,11 @@ export class MonacoMarket {
   async updateMarketLiquiditiesWithCrossLiquidity(
     sourceForOutcome: boolean,
     sourceLiquidities: { outcome: number; price: number }[],
-    crossLiquidity: { outcome: number; price: number },
   ) {
     await this.monaco.program.methods
       .updateMarketLiquiditiesWithCrossLiquidity(
         sourceForOutcome,
         sourceLiquidities,
-        crossLiquidity,
       )
       .accounts({
         marketLiquidities: this.liquiditiesPk,

--- a/tests/util/wrappers.ts
+++ b/tests/util/wrappers.ts
@@ -1082,6 +1082,7 @@ export class MonacoMarket {
         sourceLiquidities,
       )
       .accounts({
+        market: this.pk,
         marketLiquidities: this.liquiditiesPk,
       })
       .rpc()


### PR DESCRIPTION
Fixing issues with `update_market_liquidities_with_cross_liquidity` safety.

Removing `cross_liquidity` as it was inconsequential due to method determining its own cross price and stake.

Adding more validations to make it safer:
- validating that number of passed sources is 1 less that number of outcomes for this market
- validating that there is no duplicate outcome sources
- validating that there is no incorrect outcomes
- sorting source liquidities provided by outcome to make sure that all variations end up in the same liquidity bucket