### PR TITLE
fix: validating that matching queue head is the right type

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -472,6 +472,19 @@ pub struct AuthoriseOperator<'info> {
     pub system_program: Program<'info, System>,
 }
 
+// used by ProcessOrderMatchTaker
+// validates correctness of MarketMatchingQueue account
+fn taker_market_matching_queue_constraint(
+    market_matching_queue: &Account<MarketMatchingQueue>,
+) -> bool {
+    match market_matching_queue.matches.peek() {
+        Some(head) => head.pk.is_some(),
+        None => false,
+    }
+}
+
+// used by ProcessOrderMatchTaker
+// validates correctness of Order account
 fn taker_order_constraint(
     market_matching_queue: &Account<MarketMatchingQueue>,
     order: &Account<Order>,
@@ -495,6 +508,8 @@ pub struct ProcessOrderMatchTaker<'info> {
         has_one = market @ CoreError::MatchingMarketMismatch,
         constraint = !market_matching_queue.matches.is_empty()
             @ CoreError::MatchingQueueIsEmpty,
+        constraint = taker_market_matching_queue_constraint(&market_matching_queue)
+            @ CoreError::MatchingQueueHeadNotTaker,
     )]
     pub market_matching_queue: Box<Account<'info, MarketMatchingQueue>>,
 
@@ -502,7 +517,7 @@ pub struct ProcessOrderMatchTaker<'info> {
         mut,
         has_one = market @ CoreError::MatchingMarketMismatch,
         constraint = taker_order_constraint(&market_matching_queue, &order)
-            @ CoreError::MatchingPoolHeadMismatch,
+            @ CoreError::MatchingQueueHeadMismatch,
     )]
     pub order: Account<'info, Order>,
     #[account(
@@ -526,7 +541,19 @@ pub struct ProcessOrderMatchTaker<'info> {
     pub token_program: Program<'info, Token>,
 }
 
-// used by ProcessOrderMatchMaker to validate correctness of MarketMatchingPool account
+// used by ProcessOrderMatchMaker
+// validates correctness of MarketMatchingQueue account
+fn maker_market_matching_queue_constraint(
+    market_matching_queue: &Account<MarketMatchingQueue>,
+) -> bool {
+    match market_matching_queue.matches.peek() {
+        Some(head) => head.pk.is_none(),
+        None => false,
+    }
+}
+
+// used by ProcessOrderMatchMaker
+// validates correctness of MarketMatchingPool account
 fn maker_market_matching_pool_constraint(
     market_matching_queue: &Account<MarketMatchingQueue>,
     market_matching_pool: &Account<MarketMatchingPool>,
@@ -541,13 +568,14 @@ fn maker_market_matching_pool_constraint(
     }
 }
 
-// used by ProcessOrderMatchMaker to validate correctness of Order account
+// used by ProcessOrderMatchMaker
+// validates correctness of Order account
 fn maker_order_constraint(
     market_matching_pool: &Account<MarketMatchingPool>,
-    maker_order: &Account<Order>,
+    order: &Account<Order>,
 ) -> bool {
     match market_matching_pool.orders.peek(0) {
-        Some(head) => maker_order.key().eq(head),
+        Some(head_pk) => order.key().eq(head_pk),
         None => false,
     }
 }
@@ -570,6 +598,8 @@ pub struct ProcessOrderMatchMaker<'info> {
         has_one = market @ CoreError::MatchingMarketMismatch,
         constraint = !market_matching_queue.matches.is_empty()
             @ CoreError::MatchingQueueIsEmpty,
+        constraint = maker_market_matching_queue_constraint(&market_matching_queue)
+            @ CoreError::MatchingQueueHeadNotMaker,
     )]
     pub market_matching_queue: Box<Account<'info, MarketMatchingQueue>>,
     #[account(

--- a/programs/monaco_protocol/src/error.rs
+++ b/programs/monaco_protocol/src/error.rs
@@ -175,6 +175,12 @@ pub enum CoreError {
     MatchingMarketPriceMismatch,
     #[msg("Core Matching: market matching pool mismatch")]
     MatchingMarketMatchingPoolMismatch,
+    #[msg("Core Matching: market matching queue head is not taker")]
+    MatchingQueueHeadNotTaker,
+    #[msg("Core Matching: market matching queue head is not maker")]
+    MatchingQueueHeadNotMaker,
+    #[msg("Core Matching: market matching queue head mismatch")]
+    MatchingQueueHeadMismatch,
 
     #[msg("Order Matching: status closed")]
     MatchingStatusClosed,

--- a/tests/protocol/process_order_match.ts
+++ b/tests/protocol/process_order_match.ts
@@ -53,10 +53,8 @@ describe("Matching Crank", () => {
         assert.fail("This test should have thrown an error");
       },
       function (e) {
-        assert.equal(
-          e.logs[e.logs.length - 3],
-          "Program log: AnchorError caused by account: market_matching_queue. Error Code: MatchingQueueHeadNotTaker. Error Number: 6072. Error Message: Core Matching: market matching queue head is not taker.",
-        );
+        const error = AnchorError.parse(e.logs);
+        assert.equal(error.error.errorCode.code, "MatchingQueueHeadNotTaker");
       },
     );
   });
@@ -82,10 +80,8 @@ describe("Matching Crank", () => {
         assert.fail("This test should have thrown an error");
       },
       function (e) {
-        assert.equal(
-          e.logs[e.logs.length - 3],
-          "Program log: AnchorError caused by account: market_matching_queue. Error Code: MatchingQueueHeadNotMaker. Error Number: 6073. Error Message: Core Matching: market matching queue head is not maker.",
-        );
+        const error = AnchorError.parse(e.logs);
+        assert.equal(error.error.errorCode.code, "MatchingQueueHeadNotMaker");
       },
     );
   });

--- a/tests/protocol/process_order_match.ts
+++ b/tests/protocol/process_order_match.ts
@@ -52,7 +52,7 @@ describe("Matching Crank", () => {
       function (_) {
         assert.fail("This test should have thrown an error");
       },
-      function (e: AnchorError) {
+      function (e) {
         assert.equal(
           e.logs[e.logs.length - 3],
           "Program log: AnchorError caused by account: market_matching_queue. Error Code: MatchingQueueHeadNotTaker. Error Number: 6072. Error Message: Core Matching: market matching queue head is not taker.",
@@ -81,7 +81,7 @@ describe("Matching Crank", () => {
       function (_) {
         assert.fail("This test should have thrown an error");
       },
-      function (e: AnchorError) {
+      function (e) {
         assert.equal(
           e.logs[e.logs.length - 3],
           "Program log: AnchorError caused by account: market_matching_queue. Error Code: MatchingQueueHeadNotMaker. Error Number: 6073. Error Message: Core Matching: market matching queue head is not maker.",


### PR DESCRIPTION
Adding validation to `ProcessOrderMatchTaker` to make sure `MarketMatchingQueue` head is a "taker".
Adding validation to `ProcessOrderMatchMaker` to make sure `MarketMatchingQueue` head is a "maker".
In both cases making sure that the error returned is very clear.