### PR TITLE
fix: partial cancelation based on available liquidity

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -121,27 +121,19 @@ pub fn update_matching_pool_with_matched_order(
 }
 
 pub fn update_on_cancel(
-    market: &Market,
-    market_matching_queue: &MarketMatchingQueue,
     matching_pool: &mut MarketMatchingPool,
-    order_pk: &Pubkey,
-    order: &Order,
-) -> Result<bool> {
-    if market.is_inplay() && !matching_pool.inplay {
-        require!(
-            market_matching_queue.matches.is_empty(),
-            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
-        );
-        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+    amount_voided: u64,
+    voided_order: &Pubkey,
+    fully_voided: bool,
+) -> Result<()> {
+    if fully_voided {
+        matching_pool.orders.remove(voided_order);
     }
 
-    if matching_pool.orders.remove(order_pk).is_some() {
-        matching_pool.liquidity_amount = matching_pool
-            .liquidity_amount
-            .checked_sub(order.voided_stake)
-            .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    matching_pool.liquidity_amount = matching_pool
+        .liquidity_amount
+        .checked_sub(amount_voided)
+        .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
+
+    Ok(())
 }

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -124,7 +124,8 @@ pub fn update_on_cancel(
     market: &Market,
     market_matching_queue: &MarketMatchingQueue,
     matching_pool: &mut MarketMatchingPool,
-    order: &Account<Order>,
+    order_pk: &Pubkey,
+    order: &Order,
 ) -> Result<bool> {
     if market.is_inplay() && !matching_pool.inplay {
         require!(
@@ -134,7 +135,7 @@ pub fn update_on_cancel(
         matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
-    if matching_pool.orders.remove(&order.key()).is_some() {
+    if matching_pool.orders.remove(order_pk).is_some() {
         matching_pool.liquidity_amount = matching_pool
             .liquidity_amount
             .checked_sub(order.voided_stake)

--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -194,6 +194,26 @@ impl Cirque {
 }
 
 #[cfg(test)]
+pub fn mock_market_matching_pool(
+    market_pk: Pubkey,
+    market_outcome_index: u16,
+    for_outcome: bool,
+    price: f64,
+) -> MarketMatchingPool {
+    MarketMatchingPool {
+        market: market_pk,
+        market_outcome_index,
+        for_outcome,
+        price,
+        liquidity_amount: 0_u64,
+        matched_amount: 0_u64,
+        inplay: false,
+        orders: Cirque::new(1),
+        payer: Pubkey::new_unique(),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::state::market_matching_pool_account::Cirque;
     use solana_program::pubkey::Pubkey;

--- a/programs/monaco_protocol/src/state/order_account.rs
+++ b/programs/monaco_protocol/src/state/order_account.rs
@@ -68,6 +68,24 @@ impl Order {
             self.order_status = OrderStatus::Cancelled;
         }
     }
+
+    pub fn void_stake_unmatched_up_to(&mut self, limit: u64) -> Result<u64> {
+        let stake_to_void = limit.min(self.stake_unmatched);
+        self.voided_stake = self
+            .voided_stake
+            .checked_add(stake_to_void)
+            .ok_or(CoreError::ArithmeticError)?;
+        self.stake_unmatched = self
+            .stake_unmatched
+            .checked_sub(stake_to_void)
+            .ok_or(CoreError::ArithmeticError)?;
+
+        if self.stake == self.voided_stake && self.order_status == OrderStatus::Open {
+            self.order_status = OrderStatus::Cancelled;
+        }
+
+        Ok(stake_to_void)
+    }
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/tests/order/cancelation_payment_10.ts
+++ b/tests/order/cancelation_payment_10.ts
@@ -94,12 +94,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    try {
-      await market.cancel(forOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
-    } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
-    }
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -110,8 +105,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -159,12 +154,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    try {
-      await market.cancel(forOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
-    } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
-    }
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -175,8 +165,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -200,8 +190,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -251,9 +241,9 @@ describe("Order Cancelation Payment 10", () => {
     // Cancel Against 5
     try {
       await market.cancel(againstOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationLowLiquidity");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationLowLiquidity");
     }
 
     assert.deepEqual(
@@ -356,9 +346,9 @@ describe("Order Cancelation Payment 10", () => {
     // Cancel Against 5
     try {
       await market.cancel(againstOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationLowLiquidity");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationLowLiquidity");
     }
 
     assert.deepEqual(

--- a/tests/order/matching_orders_03.ts
+++ b/tests/order/matching_orders_03.ts
@@ -54,11 +54,16 @@ async function execute(outcomesCount: number) {
   );
 
   // create (n-1) orders to generate cross liquidity
-  const orders = await Promise.all(
-    makerOutcomes.map((_, outcomeIndex) =>
-      market.forOrder(outcomeIndex, 1, price, purchasers[outcomeIndex]),
-    ),
-  );
+  const orders = [];
+  for (let outcomeIndex = 0; outcomeIndex < outcomesCount - 1; outcomeIndex++) {
+    const order = await market.forOrder(
+      outcomeIndex,
+      1,
+      price,
+      purchasers[outcomeIndex],
+    );
+    orders.push(order);
+  }
   await market.processOrderRequests();
 
   // update cross liquidity
@@ -68,7 +73,6 @@ async function execute(outcomesCount: number) {
   await market.updateMarketLiquiditiesWithCrossLiquidity(
     true,
     sourceLiquidities,
-    { outcome: outcomesLastIndex, price },
   );
 
   // validate expected liquidity

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -423,9 +423,9 @@ describe("Security: Cancel Order", () => {
     try {
       await market.settle(0);
       await market.cancel(orderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationMarketStatusInvalid");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationMarketStatusInvalid");
     }
 
     // check the order wasn't cancelled


### PR DESCRIPTION
#### Reported Issue:

In a  matching approach introduced by v14 makers are at disadvantage when it comes to order cancelation. When the maker order gets created, its liquidity is added to `MarketLiquidities` account. If any portion of that liquidity gets matched  maker order is impossible to cancel until the match gets processed. This is because `unmatched_stake` of the maker order does not get updated (reduced in that case) till match gets post-processed while it is being used to determine amount being canceled. Since that amount can be bigger than available liquidity it leads to an error until match is processed.

#### Expected behaviour:
A partial cancel based on available liquidity should happen, leaving enough `unmatched_stake` to be matched in post-processing.

#### Consequences:
One of the interesting consequences of this and asynchronicity of order creation operation is that `cancel_order` endpoint partial success does not necessarily mean that  at later time rest of the order cannot be canceled. It should be possible if more liquidity is added to the given liquidity price point.
