### PR TITLE
fix: partial cancelation based on available liquidity

### DIFF
--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -121,27 +121,19 @@ pub fn update_matching_pool_with_matched_order(
 }
 
 pub fn update_on_cancel(
-    market: &Market,
-    market_matching_queue: &MarketMatchingQueue,
     matching_pool: &mut MarketMatchingPool,
-    order_pk: &Pubkey,
-    order: &Order,
-) -> Result<bool> {
-    if market.is_inplay() && !matching_pool.inplay {
-        require!(
-            market_matching_queue.matches.is_empty(),
-            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
-        );
-        matching_pool.move_to_inplay(&market.event_start_order_behaviour);
+    amount_voided: u64,
+    voided_order: &Pubkey,
+    fully_voided: bool,
+) -> Result<()> {
+    if fully_voided {
+        matching_pool.orders.remove(voided_order);
     }
 
-    if matching_pool.orders.remove(order_pk).is_some() {
-        matching_pool.liquidity_amount = matching_pool
-            .liquidity_amount
-            .checked_sub(order.voided_stake)
-            .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    matching_pool.liquidity_amount = matching_pool
+        .liquidity_amount
+        .checked_sub(amount_voided)
+        .ok_or(CoreError::MatchingLiquidityAmountUpdateError)?;
+
+    Ok(())
 }

--- a/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
+++ b/programs/monaco_protocol/src/instructions/matching/matching_pool.rs
@@ -124,7 +124,8 @@ pub fn update_on_cancel(
     market: &Market,
     market_matching_queue: &MarketMatchingQueue,
     matching_pool: &mut MarketMatchingPool,
-    order: &Account<Order>,
+    order_pk: &Pubkey,
+    order: &Order,
 ) -> Result<bool> {
     if market.is_inplay() && !matching_pool.inplay {
         require!(
@@ -134,7 +135,7 @@ pub fn update_on_cancel(
         matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
-    if matching_pool.orders.remove(&order.key()).is_some() {
+    if matching_pool.orders.remove(order_pk).is_some() {
         matching_pool.liquidity_amount = matching_pool
             .liquidity_amount
             .checked_sub(order.voided_stake)

--- a/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
+++ b/programs/monaco_protocol/src/instructions/matching/on_order_creation.rs
@@ -115,17 +115,25 @@ fn match_for_order(
     for (price, sources, stake) in &order_matches {
         if sources.is_empty() {
             // for direct liquidity match just remove it
-            market_liquidities
-                .remove_liquidity_against(order.market_outcome_index, *price, *stake)
-                .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?;
+            require_eq!(
+                market_liquidities
+                    .remove_liquidity_against(order.market_outcome_index, *price, *stake)
+                    .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?,
+                *stake,
+                CoreError::MatchingRemainingLiquidityTooSmall
+            );
         } else {
             // for cross liquidity match remove the sources
             if *stake > 0_u64 {
                 for source in sources {
                     let source_stake = calculate_stake_cross(*stake, *price, source.price);
-                    market_liquidities
-                        .remove_liquidity_for(source.outcome, source.price, source_stake)
-                        .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?;
+                    require_eq!(
+                        market_liquidities
+                            .remove_liquidity_for(source.outcome, source.price, source_stake)
+                            .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?,
+                        source_stake,
+                        CoreError::MatchingRemainingLiquidityTooSmall
+                    );
                 }
             }
             // always update even if it's 0
@@ -242,17 +250,25 @@ fn match_against_order(
     for (price, sources, stake) in &order_matches {
         if sources.is_empty() {
             // for direct liquidity match just remove it
-            market_liquidities
-                .remove_liquidity_for(order.market_outcome_index, *price, *stake)
-                .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?;
+            require_eq!(
+                market_liquidities
+                    .remove_liquidity_for(order.market_outcome_index, *price, *stake)
+                    .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?,
+                *stake,
+                CoreError::MatchingRemainingLiquidityTooSmall
+            );
         } else {
             // for cross liquidity match remove the sources
             if *stake > 0_u64 {
                 for source in sources {
                     let source_stake = calculate_stake_cross(*stake, *price, source.price);
-                    market_liquidities
-                        .remove_liquidity_against(source.outcome, source.price, source_stake)
-                        .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?;
+                    require_eq!(
+                        market_liquidities
+                            .remove_liquidity_against(source.outcome, source.price, source_stake)
+                            .map_err(|_| CoreError::MatchingRemainingLiquidityTooSmall)?,
+                        source_stake,
+                        CoreError::MatchingRemainingLiquidityTooSmall
+                    );
                 }
             }
             // always update even if it's 0

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -19,7 +19,7 @@ pub fn cancel_order(
     market_matching_queue: &MarketMatchingQueue,
     market_matching_pool: &mut MarketMatchingPool,
 ) -> Result<u64> {
-    // market is open + should be locked and cancellation is the intended behaviour
+    // market is open
     require!(
         [MarketStatus::Open].contains(&market.market_status),
         CoreError::CancelationMarketStatusInvalid

--- a/programs/monaco_protocol/src/state/market_matching_pool_account.rs
+++ b/programs/monaco_protocol/src/state/market_matching_pool_account.rs
@@ -194,6 +194,26 @@ impl Cirque {
 }
 
 #[cfg(test)]
+pub fn mock_market_matching_pool(
+    market_pk: Pubkey,
+    market_outcome_index: u16,
+    for_outcome: bool,
+    price: f64,
+) -> MarketMatchingPool {
+    MarketMatchingPool {
+        market: market_pk,
+        market_outcome_index,
+        for_outcome,
+        price,
+        liquidity_amount: 0_u64,
+        matched_amount: 0_u64,
+        inplay: false,
+        orders: Cirque::new(1),
+        payer: Pubkey::new_unique(),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::state::market_matching_pool_account::Cirque;
     use solana_program::pubkey::Pubkey;

--- a/programs/monaco_protocol/src/state/market_position_account.rs
+++ b/programs/monaco_protocol/src/state/market_position_account.rs
@@ -57,6 +57,18 @@ impl MarketPosition {
 }
 
 #[cfg(test)]
+pub fn mock_market_position(number_of_market_outcomes: usize) -> MarketPosition {
+    let mut market_position = MarketPosition::default();
+    market_position
+        .market_outcome_sums
+        .resize(number_of_market_outcomes, 0_i128);
+    market_position
+        .unmatched_exposures
+        .resize(number_of_market_outcomes, 0_u64);
+    market_position
+}
+
+#[cfg(test)]
 mod total_exposure_tests {
     use super::*;
 

--- a/programs/monaco_protocol/src/state/order_account.rs
+++ b/programs/monaco_protocol/src/state/order_account.rs
@@ -69,8 +69,7 @@ impl Order {
         }
     }
 
-    pub fn void_stake_unmatched_up_to(&mut self, limit: u64) -> Result<u64> {
-        let stake_to_void = limit.min(self.stake_unmatched);
+    pub fn void_stake_unmatched_by(&mut self, stake_to_void: u64) -> Result<()> {
         self.voided_stake = self
             .voided_stake
             .checked_add(stake_to_void)
@@ -84,7 +83,7 @@ impl Order {
             self.order_status = OrderStatus::Cancelled;
         }
 
-        Ok(stake_to_void)
+        Ok(())
     }
 }
 

--- a/programs/monaco_protocol/src/state/order_account.rs
+++ b/programs/monaco_protocol/src/state/order_account.rs
@@ -68,6 +68,24 @@ impl Order {
             self.order_status = OrderStatus::Cancelled;
         }
     }
+
+    pub fn void_stake_unmatched_up_to(&mut self, limit: u64) -> Result<u64> {
+        let stake_to_void = limit.min(self.stake_unmatched);
+        self.voided_stake = self
+            .voided_stake
+            .checked_add(stake_to_void)
+            .ok_or(CoreError::ArithmeticError)?;
+        self.stake_unmatched = self
+            .stake_unmatched
+            .checked_sub(stake_to_void)
+            .ok_or(CoreError::ArithmeticError)?;
+
+        if self.stake == self.voided_stake && self.order_status == OrderStatus::Open {
+            self.order_status = OrderStatus::Cancelled;
+        }
+
+        Ok(stake_to_void)
+    }
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/tests/order/cancelation_payment_10.ts
+++ b/tests/order/cancelation_payment_10.ts
@@ -94,12 +94,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    try {
-      await market.cancel(forOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
-    } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
-    }
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -110,8 +105,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -159,12 +154,7 @@ describe("Order Cancelation Payment 10", () => {
     );
 
     // Cancel For 10
-    try {
-      await market.cancel(forOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
-    } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
-    }
+    await market.cancel(forOrderPk, purchaser);
 
     assert.deepEqual(
       await Promise.all([
@@ -175,8 +165,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -200,8 +190,8 @@ describe("Order Cancelation Payment 10", () => {
         market.getTokenBalance(purchaser),
       ]),
       [
-        { matched: [5, -15, 5], unmatched: [10, 0, 10] },
-        { len: 1, liquidity: 10, matched: 0 },
+        { matched: [5, -15, 5], unmatched: [5, 0, 5] },
+        { len: 1, liquidity: 5, matched: 0 },
         { len: 0, liquidity: 0, matched: 5 },
         15,
         85,
@@ -251,9 +241,9 @@ describe("Order Cancelation Payment 10", () => {
     // Cancel Against 5
     try {
       await market.cancel(againstOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationLowLiquidity");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationLowLiquidity");
     }
 
     assert.deepEqual(
@@ -356,9 +346,9 @@ describe("Order Cancelation Payment 10", () => {
     // Cancel Against 5
     try {
       await market.cancel(againstOrderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationLowLiquidity");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationLowLiquidity");
     }
 
     assert.deepEqual(

--- a/tests/order/cancelation_payment_12.ts
+++ b/tests/order/cancelation_payment_12.ts
@@ -1,0 +1,76 @@
+import assert from "assert";
+import { createWalletWithBalance } from "../util/test_util";
+import { monaco } from "../util/wrappers";
+
+/*
+ * Order Cancellation Payment 12
+ *
+ * In this scenario we are testing ability to cancel maker order in presence of
+ * superior liquidity even if it's added after match has been made but still not resolved
+ * (between order is created and match is processed).
+ *
+ * In this scenario maker order is created and fully matched, but it is still not processed.
+ * Cancellation at this point should fail since there is no available liquidity.
+ * HHowever after more liquidity is added it should succeed.
+ */
+describe("Order Cancellation Payment 12", () => {
+  it("cancel after more liquidity added before match resolves", async () => {
+    // Given
+    // Create market, purchaser
+    const [purchaser1, purchaser2, purchaser3, market] = await Promise.all([
+      createWalletWithBalance(monaco.provider),
+      createWalletWithBalance(monaco.provider),
+      createWalletWithBalance(monaco.provider),
+      monaco.create3WayMarket([3.0]),
+    ]);
+    await market.airdrop(purchaser1, 100.0);
+    await market.airdrop(purchaser2, 100.0);
+    await market.airdrop(purchaser3, 100.0);
+
+    // Create orders
+    const forOrder1Pk = await market.forOrder(1, 10.0, 3.0, purchaser1);
+    await market.againstOrder(1, 10.0, 3.0, purchaser2);
+
+    // Try to cancel the maker order
+    try {
+      await market.cancel(forOrder1Pk, purchaser1);
+      assert.fail("expected CancelationLowLiquidity");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "CancelationLowLiquidity");
+    }
+    assert.deepEqual(await monaco.getOrder(forOrder1Pk), {
+      stakeUnmatched: 10,
+      stakeVoided: 0,
+      status: { open: {} },
+    });
+
+    // Create more maker liquidity
+    const forOrder2Pk = await market.forOrder(1, 10.0, 3.0, purchaser3);
+    assert.deepEqual(await monaco.getOrder(forOrder2Pk), {
+      stakeUnmatched: 10,
+      stakeVoided: 0,
+      status: { open: {} },
+    });
+
+    // Try to cancel the maker order again
+    await market.cancel(forOrder1Pk, purchaser1);
+    try {
+      await monaco.getOrder(forOrder1Pk);
+      assert.fail("Account should not exist");
+    } catch (e) {
+      assert.equal(
+        e.message,
+        "Account does not exist or has no data " + forOrder1Pk,
+      );
+    }
+
+    // Match orders
+    await market.processMatchingQueue();
+
+    assert.deepEqual(await monaco.getOrder(forOrder2Pk), {
+      stakeUnmatched: 0,
+      stakeVoided: 0,
+      status: { matched: {} },
+    });
+  });
+});

--- a/tests/order/matching_orders_03.ts
+++ b/tests/order/matching_orders_03.ts
@@ -54,11 +54,16 @@ async function execute(outcomesCount: number) {
   );
 
   // create (n-1) orders to generate cross liquidity
-  const orders = await Promise.all(
-    makerOutcomes.map((_, outcomeIndex) =>
-      market.forOrder(outcomeIndex, 1, price, purchasers[outcomeIndex]),
-    ),
-  );
+  const orders = [];
+  for (let outcomeIndex = 0; outcomeIndex < outcomesCount - 1; outcomeIndex++) {
+    const order = await market.forOrder(
+      outcomeIndex,
+      1,
+      price,
+      purchasers[outcomeIndex],
+    );
+    orders.push(order);
+  }
   await market.processOrderRequests();
 
   // update cross liquidity
@@ -68,7 +73,6 @@ async function execute(outcomesCount: number) {
   await market.updateMarketLiquiditiesWithCrossLiquidity(
     true,
     sourceLiquidities,
-    { outcome: outcomesLastIndex, price },
   );
 
   // validate expected liquidity

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -423,9 +423,9 @@ describe("Security: Cancel Order", () => {
     try {
       await market.settle(0);
       await market.cancel(orderPk, purchaser);
-      assert.fail("expected CancelOrderNotCancellable");
+      assert.fail("expected CancelationMarketStatusInvalid");
     } catch (e) {
-      assert.equal(e.error.errorCode.code, "CancelOrderNotCancellable");
+      assert.equal(e.error.errorCode.code, "CancelationMarketStatusInvalid");
     }
 
     // check the order wasn't cancelled


### PR DESCRIPTION
#### Reported Issue:

In a  matching approach introduced by v14 makers are at disadvantage when it comes to order cancelation. When the maker order gets created, its liquidity is added to `MarketLiquidities` account. If any portion of that liquidity gets matched  maker order is impossible to cancel until the match gets processed. This is because `unmatched_stake` of the maker order does not get updated (reduced in that case) till match gets post-processed while it is being used to determine amount being canceled. Since that amount can be bigger than available liquidity it leads to an error until match is processed.

#### Expected behaviour:
A partial cancel based on available liquidity should happen, leaving enough `unmatched_stake` to be matched in post-processing.

#### Consequences:
One of the interesting consequences of this and asynchronicity of order creation operation is that `cancel_order` endpoint partial success does not necessarily mean that  at later time rest of the order cannot be canceled. It should be possible if more liquidity is added to the given liquidity price point.
