### PR TITLE
release: v0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "monaco_protocol"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/monaco_protocol/Cargo.toml
+++ b/programs/monaco_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco_protocol"
-version = "0.15.1"
+version = "0.15.2"
 description = "Created with Anchor"
 edition = "2018"
 

--- a/programs/monaco_protocol/src/state/market_order_request_queue.rs
+++ b/programs/monaco_protocol/src/state/market_order_request_queue.rs
@@ -9,7 +9,7 @@ pub struct MarketOrderRequestQueue {
 }
 
 impl MarketOrderRequestQueue {
-    pub const QUEUE_LENGTH: u32 = 75;
+    pub const QUEUE_LENGTH: u32 = 50;
 
     pub const SIZE: usize = DISCRIMINATOR_SIZE +
         PUB_KEY_SIZE + // market

--- a/tests/protocol/create_order_request.ts
+++ b/tests/protocol/create_order_request.ts
@@ -1,0 +1,46 @@
+import { createWalletWithBalance } from "../util/test_util";
+import assert from "assert";
+import { DEFAULT_PRICE_LADDER } from "../../npm-client/";
+import { monaco } from "../util/wrappers";
+
+describe("Protocol - Create Order Request", () => {
+  it("fill up the queue", async () => {
+    const prices = DEFAULT_PRICE_LADDER;
+
+    const [purchaser, market] = await Promise.all([
+      createWalletWithBalance(monaco.provider),
+      monaco.create3WayMarket(prices),
+    ]);
+    await market.airdrop(purchaser, 1000.0);
+
+    let i = 0;
+    try {
+      for (; i < 100; i += 1) {
+        await market.forOrderRequest(0, 1.0, prices[i], purchaser);
+      }
+      fail("expected OrderRequestCreationQueueFull.");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "OrderRequestCreationQueueFull");
+    }
+
+    assert.equal((await market.getOrderRequestQueue()).orderRequests.len, 50);
+
+    await market.processNextOrderRequest();
+
+    assert.equal((await market.getOrderRequestQueue()).orderRequests.len, 49);
+
+    try {
+      await market.forOrderRequest(0, 1.0, prices[i], purchaser);
+    } catch (e) {
+      fail(e);
+    }
+
+    try {
+      await market.forOrderRequest(0, 1.0, prices[i], purchaser);
+      fail("expected OrderRequestCreationQueueFull.");
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "OrderRequestCreationQueueFull");
+    }
+    assert.equal((await market.getOrderRequestQueue()).orderRequests.len, 50);
+  });
+});


### PR DESCRIPTION
We have raised queue length to `75` but that have resulted in 
```
  logs: [
    'Program monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih invoke [1]',
    'Program log: Instruction: CreateOrderRequest',
    'Program 11111111111111111111111111111111 invoke [2]',
    'Program 11111111111111111111111111111111 success',
    'Program log: Error: memory allocation failed, out of memory',
    'Program monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih consumed 90035 of 200000 compute units',
    'Program monacoUXKtUi6vKsQwaLyxmXKSievfNWEcYXTgkbCih failed: SBF program panicked'
  ],
```
After investigation we have determined that when queue length was to be changed from `55` to `56` the memory reallocation caused by `Vec` implementation to temporarily exceed transaction's limit and cause error. 