### PR TITLE
chore: cancel endpoints review

### DIFF
--- a/programs/monaco_protocol/src/context.rs
+++ b/programs/monaco_protocol/src/context.rs
@@ -371,12 +371,6 @@ pub struct CancelOrderPostMarketLock<'info> {
     pub order_request_queue: Account<'info, MarketOrderRequestQueue>,
 
     #[account(
-        seeds = [b"matching".as_ref(), market.key().as_ref()],
-        bump,
-    )]
-    pub matching_queue: Account<'info, MarketMatchingQueue>,
-
-    #[account(
         mut,
         seeds = [
             market.key().as_ref(),

--- a/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
+++ b/programs/monaco_protocol/src/instructions/market/move_to_inplay.rs
@@ -35,6 +35,25 @@ pub fn move_market_to_inplay(
     Ok(())
 }
 
+pub fn move_market_to_inplay_if_needed(
+    market: &mut Market,
+    market_liquidities: &mut MarketLiquidities,
+) -> Result<()> {
+    let now = current_timestamp();
+
+    require!(
+        Open.eq(&market.market_status),
+        CoreError::MarketNotOpenForInplay
+    );
+
+    if market.inplay_enabled && market.event_start_timestamp <= now && !market.inplay {
+        market.move_to_inplay();
+        market_liquidities.move_to_inplay(&market.event_start_order_behaviour);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::instructions::current_timestamp;

--- a/programs/monaco_protocol/src/instructions/market_position/update_on_order_cancellation.rs
+++ b/programs/monaco_protocol/src/instructions/market_position/update_on_order_cancellation.rs
@@ -8,12 +8,13 @@ use anchor_lang::prelude::*;
 pub fn update_on_order_cancellation(
     market_position: &mut MarketPosition,
     order: &Order,
+    stake_to_void: u64,
 ) -> Result<u64> {
     let outcome_index = order.market_outcome_index as usize;
     let for_outcome = order.for_outcome;
     let order_exposure = match for_outcome {
-        true => order.voided_stake,
-        false => calculate_risk_from_stake(order.voided_stake, order.expected_price),
+        true => stake_to_void,
+        false => calculate_risk_from_stake(stake_to_void, order.expected_price),
     };
 
     update_exposures(market_position, outcome_index, for_outcome, order_exposure)

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -36,6 +36,7 @@ pub fn cancel_order(
 
     move_market_to_inplay_if_needed(market, market_liquidities)?;
     // move_market_matching_pool_to_inplay_if_needed
+    // !!! move_market_to_inplay_if_needed needs to be called first
     if market.inplay && !market_matching_pool.inplay {
         require!(
             market_matching_queue.matches.is_empty(),

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::error::CoreError;
-use crate::instructions::market::move_market_to_inplay;
+use crate::instructions::market::move_market_to_inplay_if_needed;
 use crate::instructions::{market_position, matching};
 use crate::state::market_account::{Market, MarketStatus};
 use crate::state::market_liquidities::{LiquiditySource, MarketLiquidities};
@@ -34,21 +34,32 @@ pub fn cancel_order(
         CoreError::CancelOrderNotCancellable
     );
 
-    // if market is inplay, but the inplay flag hasn't been flipped yet, do it now
-    // and zero liquidities and the matching pool
-    if market.is_inplay() {
-        if !market.inplay {
-            move_market_to_inplay(market, market_liquidities)?;
-        }
-        if !market_matching_pool.inplay {
-            require!(
-                market_matching_queue.matches.is_empty(),
-                CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
-            );
-            market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
-        }
+    move_market_to_inplay_if_needed(market, market_liquidities)?;
+    // move_market_matching_pool_to_inplay_if_needed
+    if market.inplay && !market_matching_pool.inplay {
+        require!(
+            market_matching_queue.matches.is_empty(),
+            CoreError::InplayTransitionMarketMatchingQueueIsNotEmpty
+        );
+        market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
+    cancel_order_common(
+        market_liquidities,
+        market_matching_pool,
+        order_pk,
+        order,
+        market_position,
+    )
+}
+
+pub fn cancel_order_common(
+    market_liquidities: &mut MarketLiquidities,
+    market_matching_pool: &mut MarketMatchingPool,
+    order_pk: &Pubkey,
+    order: &mut Order,
+    market_position: &mut MarketPosition,
+) -> Result<u64> {
     // check how much liquidity is left and void it
     let stake_to_void = match order.for_outcome {
         true => market_liquidities
@@ -90,22 +101,18 @@ pub fn cancel_order(
 
     // calculate refund
     // TODO need to pass the voided stake value as this might be second (or third, etc) void
-    let refund = market_position::update_on_order_cancellation(market_position, order)?;
-
-    Ok(refund)
+    market_position::update_on_order_cancellation(market_position, order)
 }
 
 #[cfg(test)]
-mod test {
+mod test_cancel_order_common {
     use super::*;
-    use crate::state::market_account::{mock_market, MarketStatus};
     use crate::state::market_liquidities::{mock_market_liquidities, MarketOutcomePriceLiquidity};
     use crate::state::market_matching_pool_account::mock_market_matching_pool;
-    use crate::state::market_matching_queue_account::mock_market_matching_queue;
     use crate::state::market_position_account::mock_market_position;
 
     #[test]
-    fn full_cancellation() {
+    fn cancellation_full() {
         let market_outcome_index = 1;
         let for_outcome = true;
         let price = 3.0_f64;
@@ -113,9 +120,7 @@ mod test {
         let payer_pk = Pubkey::new_unique();
 
         let market_pk = Pubkey::new_unique();
-        let mut market = mock_market(MarketStatus::Open);
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        let mut market_matching_queue = mock_market_matching_queue(market_pk);
 
         let order_pk = Pubkey::new_unique();
         let mut order = mock_order(
@@ -156,26 +161,26 @@ mod test {
         );
 
         // when
-        let result = cancel_order(
-            &mut market,
+        let result = cancel_order_common(
+            &mut market_liquidities,
+            &mut market_matching_pool,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_liquidities,
-            &mut market_matching_queue,
-            &mut market_matching_pool,
         );
 
         // then
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);
+        assert_eq!(0, order.stake_unmatched);
+        assert_eq!(10, order.voided_stake);
         assert_eq!(vec!(0, 0, 0), market_position.unmatched_exposures);
         assert_eq!(0, market_liquidities.liquidities_for.len());
         assert_eq!(0, market_matching_pool.orders.len());
     }
 
     #[test]
-    fn partial_cancellation() {
+    fn cancellation_partial() {
         let market_outcome_index = 1;
         let for_outcome = true;
         let price = 3.0_f64;
@@ -183,9 +188,7 @@ mod test {
         let payer_pk = Pubkey::new_unique();
 
         let market_pk = Pubkey::new_unique();
-        let mut market = mock_market(MarketStatus::Open);
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        let mut market_matching_queue = mock_market_matching_queue(market_pk);
 
         let order_pk = Pubkey::new_unique();
         let mut order = mock_order(
@@ -216,7 +219,7 @@ mod test {
         market_matching_pool.orders.enqueue(order_pk);
         market_matching_pool.liquidity_amount = stake;
 
-        // add order to market position
+        // add order to market liquidity
         market_liquidities
             .add_liquidity_for(market_outcome_index, price, stake - 1) // less than unmatched stake
             .expect("");
@@ -226,26 +229,26 @@ mod test {
         );
 
         // when
-        let result = cancel_order(
-            &mut market,
+        let result = cancel_order_common(
+            &mut market_liquidities,
+            &mut market_matching_pool,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_liquidities,
-            &mut market_matching_queue,
-            &mut market_matching_pool,
         );
 
         // then
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 9);
+        assert_eq!(1, order.stake_unmatched);
+        assert_eq!(9, order.voided_stake);
         assert_eq!(vec!(1, 0, 1), market_position.unmatched_exposures);
         assert_eq!(0, market_liquidities.liquidities_for.len());
         assert_eq!(1, market_matching_pool.orders.len());
     }
 
     #[test]
-    fn no_cancellation() {
+    fn cancellation_none() {
         let market_outcome_index = 1;
         let for_outcome = true;
         let price = 3.0_f64;
@@ -253,9 +256,7 @@ mod test {
         let payer_pk = Pubkey::new_unique();
 
         let market_pk = Pubkey::new_unique();
-        let mut market = mock_market(MarketStatus::Open);
         let mut market_liquidities = mock_market_liquidities(market_pk);
-        let mut market_matching_queue = mock_market_matching_queue(market_pk);
 
         let order_pk = Pubkey::new_unique();
         let mut order = mock_order(
@@ -286,18 +287,16 @@ mod test {
         market_matching_pool.orders.enqueue(order_pk);
         market_matching_pool.liquidity_amount = stake;
 
-        // add order to market position
+        // add order to market liquidity
         assert!(liquidities(&market_liquidities.liquidities_for).is_empty());
 
         // when
-        let result = cancel_order(
-            &mut market,
+        let result = cancel_order_common(
+            &mut market_liquidities,
+            &mut market_matching_pool,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_liquidities,
-            &mut market_matching_queue,
-            &mut market_matching_pool,
         );
 
         // then
@@ -306,6 +305,8 @@ mod test {
             result.unwrap_err(),
             error!(CoreError::CancelationLowLiquidity)
         );
+        assert_eq!(10, order.stake_unmatched);
+        assert_eq!(0, order.voided_stake);
         assert_eq!(vec!(10, 0, 10), market_position.unmatched_exposures);
         assert_eq!(0, market_liquidities.liquidities_for.len());
         assert_eq!(1, market_matching_pool.orders.len());
@@ -316,5 +317,204 @@ mod test {
             .iter()
             .map(|v| (v.outcome, v.price, v.liquidity))
             .collect::<Vec<(u16, f64, u64)>>()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::instructions::market_position;
+    use crate::state::market_account::{mock_market, MarketOrderBehaviour, MarketStatus};
+    use crate::state::market_liquidities::mock_market_liquidities;
+    use crate::state::market_matching_pool_account::mock_market_matching_pool;
+    use crate::state::market_matching_queue_account::mock_market_matching_queue;
+    use crate::state::market_position_account::mock_market_position;
+    use crate::state::order_account::{mock_order, OrderStatus};
+
+    use super::*;
+
+    #[test]
+    fn error_market_status_invalid() {
+        let (
+            _market_outcome_index,
+            _for_outcome,
+            _price,
+            mut market,
+            order_pk,
+            mut order,
+            mut market_position,
+            mut market_matching_pool,
+            mut market_liquidities,
+            mut market_matching_queue,
+        ) = setup_for_cancellation(100, 10);
+        market.market_status = MarketStatus::Settled;
+
+        let result = cancel_order(
+            &mut market,
+            &order_pk,
+            &mut order,
+            &mut market_position,
+            &mut market_liquidities,
+            &mut market_matching_queue,
+            &mut market_matching_pool,
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::CancelationMarketStatusInvalid)
+        );
+    }
+
+    #[test]
+    fn error_order_status_invalid() {
+        let (
+            _market_outcome_index,
+            _for_outcome,
+            _price,
+            mut market,
+            order_pk,
+            mut order,
+            mut market_position,
+            mut market_matching_pool,
+            mut market_liquidities,
+            mut market_matching_queue,
+        ) = setup_for_cancellation(100, 10);
+        order.order_status = OrderStatus::SettledWin;
+
+        let result = cancel_order(
+            &mut market,
+            &order_pk,
+            &mut order,
+            &mut market_position,
+            &mut market_liquidities,
+            &mut market_matching_queue,
+            &mut market_matching_pool,
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::CancelationOrderStatusInvalid)
+        );
+    }
+
+    #[test]
+    fn error_order_stake_unmatched_zero() {
+        let (
+            _market_outcome_index,
+            _for_outcome,
+            _price,
+            mut market,
+            order_pk,
+            mut order,
+            mut market_position,
+            mut market_matching_pool,
+            mut market_liquidities,
+            mut market_matching_queue,
+        ) = setup_for_cancellation(100, 10);
+        market.unsettled_accounts_count = 1;
+
+        let result = cancel_order(
+            &mut market,
+            &order_pk,
+            &mut order,
+            &mut market_position,
+            &mut market_liquidities,
+            &mut market_matching_queue,
+            &mut market_matching_pool,
+        );
+        assert!(result.is_ok());
+        assert_eq!(14, result.unwrap());
+        assert_eq!(10, order.voided_stake);
+        assert_eq!(0, order.stake_unmatched);
+        assert_eq!(OrderStatus::Matched, order.order_status);
+        assert_eq!(1, market.unsettled_accounts_count);
+
+        let result = cancel_order(
+            &mut market,
+            &order_pk,
+            &mut order,
+            &mut market_position,
+            &mut market_liquidities,
+            &mut market_matching_queue,
+            &mut market_matching_pool,
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            error!(CoreError::CancelOrderNotCancellable)
+        );
+    }
+
+    fn setup_for_cancellation<'test>(
+        stake: u64,
+        stake_unmatched: u64,
+    ) -> (
+        u16,
+        bool,
+        f64,
+        Market,
+        Pubkey,
+        Order,
+        MarketPosition,
+        MarketMatchingPool,
+        MarketLiquidities,
+        MarketMatchingQueue,
+    ) {
+        let market_outcome_index = 1;
+        let for_outcome = false;
+        let price = 2.4_f64;
+
+        let market_pk = Pubkey::new_unique();
+        let mut market = mock_market(MarketStatus::Open);
+        market.market_lock_order_behaviour = MarketOrderBehaviour::CancelUnmatched;
+
+        let order_pk = Pubkey::new_unique();
+        let mut order = mock_order(
+            market_pk,
+            market_outcome_index,
+            for_outcome,
+            price,
+            stake,
+            Pubkey::new_unique(),
+        );
+        order.stake_unmatched = stake_unmatched;
+        if stake_unmatched < stake {
+            order.order_status = OrderStatus::Matched;
+        }
+
+        let mut market_position = mock_market_position(3);
+        let _ = market_position::update_on_order_request_creation(
+            &mut market_position,
+            market_outcome_index,
+            for_outcome,
+            stake,
+            price,
+        );
+
+        let mut market_matching_pool =
+            mock_market_matching_pool(market_pk, market_outcome_index, for_outcome, price);
+        market_matching_pool.orders.enqueue(order_pk);
+        market_matching_pool.liquidity_amount = order.stake_unmatched;
+
+        let mut market_liquidities = mock_market_liquidities(market_pk);
+        _ = market_liquidities.add_liquidity_against(
+            market_outcome_index,
+            price,
+            order.stake_unmatched,
+        );
+
+        let market_matching_queue = mock_market_matching_queue(market_pk);
+
+        (
+            market_outcome_index,
+            for_outcome,
+            price,
+            market,
+            order_pk,
+            order,
+            market_position,
+            market_matching_pool,
+            market_liquidities,
+            market_matching_queue,
+        )
     }
 }

--- a/programs/monaco_protocol/src/instructions/order/cancel_order.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order.rs
@@ -101,8 +101,7 @@ pub fn cancel_order_common(
     }
 
     // calculate refund
-    // TODO need to pass the voided stake value as this might be second (or third, etc) void
-    market_position::update_on_order_cancellation(market_position, order)
+    market_position::update_on_order_cancellation(market_position, order, stake_to_void)
 }
 
 #[cfg(test)]

--- a/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
@@ -18,12 +18,11 @@ pub fn cancel_order_post_market_lock(
     market_matching_pool: &mut MarketMatchingPool,
     order_request_queue: &MarketOrderRequestQueue,
 ) -> Result<u64> {
-    // market is open
+    // market is open + should be locked and cancellation is the intended behaviour
     require!(
         [MarketStatus::Open].contains(&market.market_status),
         CoreError::CancelationMarketStatusInvalid
     );
-    // market should be locked and cancellation is the intended behaviour
     require!(
         market.market_lock_timestamp <= current_timestamp(),
         CoreError::CancelationMarketNotLocked

--- a/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_order_post_market_lock.rs
@@ -1,10 +1,9 @@
 use crate::error::CoreError;
 use crate::instructions::clock::current_timestamp;
-use crate::instructions::{market_position, matching};
+use crate::instructions::order::cancel_order_common;
 use crate::state::market_account::{Market, MarketOrderBehaviour, MarketStatus};
-use crate::state::market_liquidities::{LiquiditySource, MarketLiquidities};
+use crate::state::market_liquidities::MarketLiquidities;
 use crate::state::market_matching_pool_account::MarketMatchingPool;
-use crate::state::market_matching_queue_account::MarketMatchingQueue;
 use crate::state::market_order_request_queue::MarketOrderRequestQueue;
 use crate::state::market_position_account::MarketPosition;
 use crate::state::order_account::{Order, OrderStatus};
@@ -15,16 +14,16 @@ pub fn cancel_order_post_market_lock(
     order_pk: &Pubkey,
     order: &mut Order,
     market_position: &mut MarketPosition,
-    market_matching_pool: &mut MarketMatchingPool,
     market_liquidities: &mut MarketLiquidities,
-    matching_queue: &MarketMatchingQueue,
+    market_matching_pool: &mut MarketMatchingPool,
     order_request_queue: &MarketOrderRequestQueue,
 ) -> Result<u64> {
-    // market is open + should be locked and cancellation is the intended behaviour
+    // market is open
     require!(
         [MarketStatus::Open].contains(&market.market_status),
         CoreError::CancelationMarketStatusInvalid
     );
+    // market should be locked and cancellation is the intended behaviour
     require!(
         market.market_lock_timestamp <= current_timestamp(),
         CoreError::CancelationMarketNotLocked
@@ -33,10 +32,7 @@ pub fn cancel_order_post_market_lock(
         MarketOrderBehaviour::CancelUnmatched.eq(&market.market_lock_order_behaviour),
         CoreError::CancelationMarketOrderBehaviourInvalid
     );
-    require!(
-        matching_queue.matches.is_empty(),
-        CoreError::MatchingQueueIsNotEmpty
-    );
+    // make sure that all orders had a chance to match
     require!(
         order_request_queue.order_requests.is_empty(),
         CoreError::OrderRequestQueueIsNotEmpty
@@ -52,60 +48,21 @@ pub fn cancel_order_post_market_lock(
         CoreError::CancelOrderNotCancellable
     );
 
-    // check how much liquidity is left and void it
-    let stake_to_void = match order.for_outcome {
-        true => market_liquidities
-            .remove_liquidity_for(
-                order.market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .map_err(|_| CoreError::CancelationLowLiquidity)?,
-        false => market_liquidities
-            .remove_liquidity_against(
-                order.market_outcome_index,
-                order.expected_price,
-                order.stake_unmatched,
-            )
-            .map_err(|_| CoreError::CancelationLowLiquidity)?,
-    };
-    order.void_stake_unmatched_by(stake_to_void)?;
-
-    // remove liquidity from the matching pool and order if needed
-    matching::matching_pool::update_on_cancel(
+    cancel_order_common(
+        market_liquidities,
         market_matching_pool,
-        stake_to_void,
         order_pk,
-        order.stake_unmatched == 0_u64,
-    )?;
-
-    // compute cost of this operation grows linear with the number of liquidity points,
-    // so it is disabled in production but left in for further testing
-    let update_derived_liquidity = false; // flag indicating removal of cross liquidity
-    if update_derived_liquidity {
-        let liquidity_source =
-            LiquiditySource::new(order.market_outcome_index, order.expected_price);
-        match order.for_outcome {
-            true => market_liquidities.update_all_cross_liquidity_against(&liquidity_source),
-            false => market_liquidities.update_all_cross_liquidity_for(&liquidity_source),
-        }
-    }
-
-    if OrderStatus::Cancelled.eq(&order.order_status) {
-        market.decrement_unsettled_accounts_count()?;
-    }
-
-    // calculate refund
-    // TODO need to pass the voided stake value as this might be second (or third, etc) void
-    market_position::update_on_order_cancellation(market_position, order)
+        order,
+        market_position,
+    )
 }
 
 #[cfg(test)]
 mod test {
+    use crate::instructions::market_position;
     use crate::state::market_account::{mock_market, MarketStatus};
     use crate::state::market_liquidities::mock_market_liquidities;
     use crate::state::market_matching_pool_account::mock_market_matching_pool;
-    use crate::state::market_matching_queue_account::{mock_market_matching_queue, OrderMatch};
     use crate::state::market_order_request_queue::{mock_order_request, mock_order_request_queue};
     use crate::state::market_position_account::mock_market_position;
     use crate::state::order_account::{mock_order, OrderStatus};
@@ -113,7 +70,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn error_market_queues_not_empty() {
+    fn error_market_order_request_queue_not_empty() {
         let (
             market_outcome_index,
             for_outcome,
@@ -124,68 +81,44 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            mut matching_queue,
-            mut request_queue,
+            mut market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
-        matching_queue.matches.enqueue(OrderMatch::maker(
-            false,
-            market_outcome_index,
-            price,
-            order.stake - order.stake_unmatched,
-        ));
-        request_queue.order_requests.enqueue(mock_order_request(
-            order.purchaser,
-            for_outcome,
-            market_outcome_index,
-            order.stake,
-            price,
-        ));
+        market_order_request_queue
+            .order_requests
+            .enqueue(mock_order_request(
+                order.purchaser,
+                for_outcome,
+                market_outcome_index,
+                order.stake,
+                price,
+            ));
 
         let result = cancel_order_post_market_lock(
             &mut market,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
-        );
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            error!(CoreError::MatchingQueueIsNotEmpty)
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
 
-        matching_queue.matches.dequeue();
-
-        let result = cancel_order_post_market_lock(
-            &mut market,
-            &order_pk,
-            &mut order,
-            &mut market_position,
-            &mut market_matching_pool,
-            &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
-        );
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
             error!(CoreError::OrderRequestQueueIsNotEmpty)
         );
 
-        request_queue.order_requests.dequeue();
+        market_order_request_queue.order_requests.dequeue();
 
         let result = cancel_order_post_market_lock(
             &mut market,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_ok());
     }
@@ -202,8 +135,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
         market.market_status = MarketStatus::Settled;
 
@@ -212,10 +144,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -236,8 +167,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
         market.market_lock_timestamp = current_timestamp() + 1000;
 
@@ -246,10 +176,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -270,8 +199,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
         market.market_lock_order_behaviour = MarketOrderBehaviour::None;
 
@@ -280,10 +208,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -304,8 +231,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
         order.order_status = OrderStatus::SettledWin;
 
@@ -314,10 +240,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -338,8 +263,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 10);
         market.unsettled_accounts_count = 1;
 
@@ -348,10 +272,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_ok());
         assert_eq!(14, result.unwrap());
@@ -365,10 +288,9 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -389,8 +311,7 @@ mod test {
             mut market_position,
             mut market_matching_pool,
             mut market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         ) = setup_for_cancellation(100, 100);
         market.unsettled_accounts_count = 1;
 
@@ -399,27 +320,24 @@ mod test {
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_ok());
         assert_eq!(140, result.unwrap());
         assert_eq!(100, order.voided_stake);
         assert_eq!(0, order.stake_unmatched);
         assert_eq!(OrderStatus::Cancelled, order.order_status);
-        assert_eq!(0, market.unsettled_accounts_count);
 
         let result = cancel_order_post_market_lock(
             &mut market,
             &order_pk,
             &mut order,
             &mut market_position,
-            &mut market_matching_pool,
             &mut market_liquidities,
-            &matching_queue,
-            &request_queue,
+            &mut market_matching_pool,
+            &market_order_request_queue,
         );
         assert!(result.is_err());
         assert_eq!(
@@ -441,7 +359,6 @@ mod test {
         MarketPosition,
         MarketMatchingPool,
         MarketLiquidities,
-        MarketMatchingQueue,
         MarketOrderRequestQueue,
     ) {
         let market_outcome_index = 1;
@@ -487,8 +404,7 @@ mod test {
             order.stake_unmatched,
         );
 
-        let matching_queue = mock_market_matching_queue(order.market);
-        let request_queue = mock_order_request_queue(order.market);
+        let market_order_request_queue = mock_order_request_queue(market_pk);
 
         (
             market_outcome_index,
@@ -500,8 +416,7 @@ mod test {
             market_position,
             market_matching_pool,
             market_liquidities,
-            matching_queue,
-            request_queue,
+            market_order_request_queue,
         )
     }
 }

--- a/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
+++ b/programs/monaco_protocol/src/instructions/order/cancel_preplay_order_post_event_start.rs
@@ -65,8 +65,10 @@ pub fn cancel_preplay_order_post_event_start(
         market_matching_pool.move_to_inplay(&market.event_start_order_behaviour);
     }
 
-    order.void_stake_unmatched(); // <-- void needs to happen before refund calculation
-    market_position::update_on_order_cancellation(market_position, order)
+    // liquidity check is not needed since all matches were processed before we got here
+    let stake_to_void = order.stake_unmatched;
+    order.void_stake_unmatched();
+    market_position::update_on_order_cancellation(market_position, order, stake_to_void)
 }
 
 #[cfg(test)]

--- a/tests/protocol/cancel_order.ts
+++ b/tests/protocol/cancel_order.ts
@@ -653,85 +653,85 @@ describe("Security: Cancel Order", () => {
       liquiditiesFor: [],
     });
   });
-});
 
-it("cancel matched order (inplay): fails as liquidity removed", async () => {
-  // Set up Market and related accounts
-  // Create market, purchaser
-  const [market, purchaser1, purchaser2] = await Promise.all([
-    monaco.create3WayMarketWithInplay([2.0, 3.0]),
-    createWalletWithBalance(monaco.provider),
-    createWalletWithBalance(monaco.provider),
-  ]);
-  await market.airdrop(purchaser1, 10_000);
-  await market.airdrop(purchaser2, 10_000);
+  it("cancel matched order (inplay): fails as liquidity removed", async () => {
+    // Set up Market and related accounts
+    // Create market, purchaser
+    const [market, purchaser1, purchaser2] = await Promise.all([
+      monaco.create3WayMarketWithInplay([2.0, 3.0]),
+      createWalletWithBalance(monaco.provider),
+      createWalletWithBalance(monaco.provider),
+    ]);
+    await market.airdrop(purchaser1, 10_000);
+    await market.airdrop(purchaser2, 10_000);
 
-  const makerPk = await market.forOrder(0, 10, 3.0, purchaser1);
-  await market.againstOrder(0, 5, 3.0, purchaser2);
-  await market.updateMarketEventStartTimeToNow();
+    const makerPk = await market.forOrder(0, 10, 3.0, purchaser1);
+    await market.againstOrder(0, 5, 3.0, purchaser2);
+    await market.updateMarketEventStartTimeToNow();
 
-  assert.deepEqual(await market.getMarketLiquidities(), {
-    liquiditiesAgainst: [],
-    liquiditiesFor: [{ liquidity: 5, outcome: 0, price: 3, sources: [] }],
-  });
+    assert.deepEqual(await market.getMarketLiquidities(), {
+      liquiditiesAgainst: [],
+      liquiditiesFor: [{ liquidity: 5, outcome: 0, price: 3, sources: [] }],
+    });
 
-  try {
-    await market.cancel(makerPk, purchaser1);
-    assert.fail("expected InplayTransitionMarketMatchingQueueIsNotEmpty");
-  } catch (e) {
-    assert.equal(
-      e.error.errorCode.code,
-      "InplayTransitionMarketMatchingQueueIsNotEmpty",
+    try {
+      await market.cancel(makerPk, purchaser1);
+      assert.fail("expected InplayTransitionMarketMatchingQueueIsNotEmpty");
+    } catch (e) {
+      assert.equal(
+        e.error.errorCode.code,
+        "InplayTransitionMarketMatchingQueueIsNotEmpty",
+      );
+    }
+
+    assert.deepEqual(
+      await Promise.all([
+        market.getMarketLiquidities(),
+        market.getMarketMatchingQueueHead(),
+      ]),
+      [
+        {
+          liquiditiesAgainst: [],
+          liquiditiesFor: [{ liquidity: 5, outcome: 0, price: 3, sources: [] }],
+        },
+        { forOutcome: true, outcomeIndex: 0, pk: null, price: 3, stake: 5 },
+      ],
     );
-  }
 
-  assert.deepEqual(
-    await Promise.all([
-      market.getMarketLiquidities(),
-      market.getMarketMatchingQueueHead(),
-    ]),
-    [
-      {
-        liquiditiesAgainst: [],
-        liquiditiesFor: [{ liquidity: 5, outcome: 0, price: 3, sources: [] }],
-      },
-      { forOutcome: true, outcomeIndex: 0, pk: null, price: 3, stake: 5 },
-    ],
-  );
+    // will erase liquidity but not matching pools
+    await market.moveMarketToInplay();
 
-  // will erase liquidity but not matching pools
-  await market.moveMarketToInplay();
+    assert.deepEqual(
+      await Promise.all([
+        market.getMarketLiquidities(),
+        market.getMarketMatchingQueueHead(),
+      ]),
+      [
+        {
+          liquiditiesAgainst: [],
+          liquiditiesFor: [],
+        },
+        { forOutcome: true, outcomeIndex: 0, pk: null, price: 3, stake: 5 },
+      ],
+    );
 
-  assert.deepEqual(
-    await Promise.all([
-      market.getMarketLiquidities(),
-      market.getMarketMatchingQueueHead(),
-    ]),
-    [
-      {
-        liquiditiesAgainst: [],
-        liquiditiesFor: [],
-      },
-      { forOutcome: true, outcomeIndex: 0, pk: null, price: 3, stake: 5 },
-    ],
-  );
+    // matching pools being still full lets us do this
+    await market.processMatchingQueue();
 
-  // matching pools being still full lets us do this
-  await market.processMatchingQueue();
-
-  assert.deepEqual(
-    await Promise.all([
-      market.getMarketLiquidities(),
-      market.getMarketMatchingQueueHead(),
-    ]),
-    [
-      {
-        liquiditiesAgainst: [],
-        liquiditiesFor: [],
-      },
-      null,
-    ],
-  );
+    assert.deepEqual(
+      await Promise.all([
+        market.getMarketLiquidities(),
+        market.getMarketMatchingQueueHead(),
+      ]),
+      [
+        {
+          liquiditiesAgainst: [],
+          liquiditiesFor: [],
+        },
+        null,
+      ],
+    );
+  });
 });
 
 async function setupUnmatchedOrder(


### PR DESCRIPTION
Reducing differences between cancel endpoints to minimum. There are 3 endpoints:
- `cancel_order`
- `cancel_order_post_market_lock`
- `cancel_preplay_order_post_event_start`.

Endpoints `cancel_order` and `cancel_order_post_market_lock` are most similar. They share the code that does the cancelation. The difference is in precondition for the code execution. Additionally `cancel_order` needs to account for markets transition into Inplay mode, where `cancel_order_post_market_lock` does not.

Endpoints `cancel_order` and `cancel_preplay_order_post_event_start` use a new `move_market_to_inplay_if_needed` function which is more convenient to use, reduces code duplication and simplifies this operation.

Endpoint `cancel_order_post_market_lock` no longer checks matching queue being empty since liquidity check supersedes it.

I've moved out counter decrements out to `lib.rs` for now to be dealt with uniformly at later time.